### PR TITLE
Pierhead & bulkhead lines per guidelines

### DIFF
--- a/public/layer-groups.json
+++ b/public/layer-groups.json
@@ -17,10 +17,10 @@
           "type":"line",
           "source":"digital-citymap",
           "source-layer":"pierhead-lines",
-          "paint":{
-            "line-color":"rgba(30, 135, 187, 1)",
-            "line-width":{
-              "stops":[
+          "paint": {
+            "line-color": "rgba(50, 120, 200, 1)",
+            "line-width": {
+              "stops": [
                 [
                   10,
                   0.5
@@ -31,11 +31,20 @@
                 ]
               ]
             },
-            "line-opacity":0.7,
-            "line-dasharray":[
-              6,
+            "line-opacity": 1,
+            "line-dasharray": [
+              5,
+              2,
+              0,
+              1.5,
+              0,
+              1.5,
+              0,
               2
             ]
+          },
+          "layout": {
+            "line-cap": "round"
           }
         }
       },
@@ -46,10 +55,10 @@
           "type":"line",
           "source":"digital-citymap",
           "source-layer":"bulkhead-lines",
-          "paint":{
-            "line-color":"rgba(160, 101, 230, 1)",
-            "line-width":{
-              "stops":[
+          "paint": {
+            "line-color": "rgba(50, 120, 200, 1)",
+            "line-width": {
+              "stops": [
                 [
                   10,
                   0.5
@@ -60,10 +69,18 @@
                 ]
               ]
             },
-            "line-dasharray":[
-              6,
-              2
+            "line-opacity": 1,
+            "line-dasharray": [
+              5,
+              2.5,
+              0,
+              2,
+              0,
+              2.5
             ]
+          },
+          "layout": {
+            "line-cap": "round"
           }
         }
       }


### PR DESCRIPTION
This PR updates the styles so that the pierhead & bulkhead lines are visualized according to the City Map Change Guidelines. 3 dots for pierhead, 2 dots for bulkhead. 

![image](https://user-images.githubusercontent.com/409279/38516528-6ac0a20c-3c05-11e8-8d1a-2de911ca1071.png)
