### PR TITLE
34 symbology tweaks

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -73,6 +73,12 @@ export default class ApplicationController extends ParachuteController {
       'highway_name_motorway',
       'tunnel_motorway_casing',
       'tunnel_motorway_inner',
+      'railway_transit',
+      'railway_transit_dashline',
+      'railway_service',
+      'railway_service_dashline',
+      'railway',
+      'railway_dashline',
     ];
 
     basemapLayersToHide.forEach(layer => map.removeLayer(layer));

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -69,8 +69,10 @@ export default class ApplicationController extends ParachuteController {
       'highway_motorway_subtle',
       'highway_motorway_bridge_casing',
       'highway_motorway_bridge_inner',
-      // 'highway_name_other',
-      // 'highway_name_motorway',
+      'highway_name_other',
+      'highway_name_motorway',
+      'tunnel_motorway_casing',
+      'tunnel_motorway_inner',
     ];
 
     basemapLayersToHide.forEach(layer => map.removeLayer(layer));

--- a/public/layer-groups.json
+++ b/public/layer-groups.json
@@ -81,16 +81,16 @@
     },
     "layers":[
       {
-        "id": "citymap-citymap-line",
+        "id": "citymap-mapped-streets-line",
         "style":{
-          "id":"citymap-citymap-line",
-          "type":"line",
-          "source":"digital-citymap",
-          "source-layer":"citymap",
-          "paint":{
-            "line-color":"rgba(51, 51, 51, 1)",
-            "line-width":{
-              "stops":[
+          "id": "citymap-mapped-streets-line",
+          "type": "line",
+          "source": "digital-citymap",
+          "source-layer": "citymap",
+          "paint": {
+            "line-color": "rgba(51, 51, 51, 1)",
+            "line-width": {
+              "stops": [
                 [
                   10,
                   0.1
@@ -105,6 +105,249 @@
                 ]
               ]
             }
+          },
+          "filter": [
+            "all",
+            [
+              "==",
+              "type",
+              "Mapped Street"
+            ]
+          ]
+        }
+      },
+      {
+        "id": "citymap-record-streets-line",
+        "style":{
+          "id": "citymap-record-streets-line",
+          "type": "line",
+          "source": "digital-citymap",
+          "source-layer": "citymap",
+          "filter": [
+            "all",
+            [
+              "==",
+              "type",
+              "Record Street"
+            ]
+          ],
+          "paint": {
+            "line-color": "rgba(0, 0, 0, 1)",
+            "line-width": {
+              "stops": [
+                [
+                  10,
+                  0.1
+                ],
+                [
+                  13,
+                  0.5
+                ],
+                [
+                  15,
+                  2
+                ]
+              ]
+            },
+            "line-dasharray": {
+              "stops": [
+                [
+                  10,
+                  [
+                    6,
+                    4
+                  ]
+                ],
+                [
+                  15,
+                  [
+                    3,
+                    1
+                  ]
+                ]
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": "citymap-street-treatments-line",
+        "style":{
+          "id": "citymap-street-treatments-line",
+          "type": "line",
+          "source": "digital-citymap",
+          "source-layer": "citymap",
+          "filter": [
+            "all",
+            [
+              "==",
+              "type",
+              "street_treatment"
+            ]
+          ],
+          "paint": {
+            "line-color": "rgba(84, 84, 84, 1)",
+            "line-width": {
+              "stops": [
+                [
+                  10,
+                  0.1
+                ],
+                [
+                  13,
+                  0.25
+                ],
+                [
+                  15,
+                  1
+                ]
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": "citymap-underpass-tunnel-line",
+        "style":{
+          "id": "citymap-underpass-tunnel-line",
+          "type": "line",
+          "source": "digital-citymap",
+          "source-layer": "citymap",
+          "filter": [
+            "all",
+            [
+              "==",
+              "type",
+              "Underpass or Tunnel"
+            ]
+          ],
+          "paint": {
+            "line-color": "rgba(150, 150, 150, 1)",
+            "line-width": {
+              "stops": [
+                [
+                  10,
+                  0.1
+                ],
+                [
+                  13,
+                  0.25
+                ],
+                [
+                  15,
+                  1
+                ]
+              ]
+            },
+            "line-dasharray": {
+              "stops": [
+                [
+                  10,
+                  [
+                    6,
+                    4
+                  ]
+                ],
+                [
+                  15,
+                  [
+                    10,
+                    6
+                  ]
+                ]
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": "citymap-non-z-boundary-line",
+        "style":{
+          "id": "citymap-non-z-boundary-line",
+          "type": "line",
+          "source": "digital-citymap",
+          "source-layer": "citymap",
+          "filter": [
+            "all",
+            [
+              "==",
+              "type",
+              "non_z_boundary"
+            ]
+          ],
+          "paint": {
+            "line-color": "rgba(26, 150, 26, 1)",
+            "line-dasharray": [
+              5,
+              1,
+              2,
+              1
+            ],
+            "line-blur": 0,
+            "line-width": {
+              "stops": [
+                [
+                  10,
+                  0.1
+                ],
+                [
+                  13,
+                  1
+                ],
+                [
+                  15,
+                  3
+                ]
+              ]
+            },
+            "line-opacity": 1,
+            "line-offset": 2
+          },
+          "layout": {
+            "line-cap": "butt"
+          }
+        }
+      },
+      {
+        "id": "citymap-street-not-mapped-line",
+        "style":{
+          "id": "citymap-street-not-mapped-line",
+          "type": "line",
+          "source": "digital-citymap",
+          "source-layer": "citymap",
+          "filter": [
+            "all",
+            [
+              "==",
+              "type",
+              "Street not mapped"
+            ]
+          ],
+          "paint": {
+            "line-color": "rgba(175, 175, 175, 1)",
+            "line-width": {
+              "stops": [
+                [
+                  10,
+                  0.1
+                ],
+                [
+                  13,
+                  0.25
+                ],
+                [
+                  15,
+                  2
+                ]
+              ]
+            },
+            "line-dasharray": [
+              0,
+              2
+            ]
+          },
+          "layout": {
+            "line-cap": "round"
           }
         }
       }
@@ -207,45 +450,18 @@
     },
     "layers":[
       {
-        "id": "citymap-street-centerlines-line",
+        "id": "citymap-street-centerlines",
         "style":{
-          "id":"citymap-street-centerlines-line",
-          "type":"line",
-          "source":"digital-citymap",
-          "source-layer":"street-centerlines",
-          "paint":{
-            "line-color":"#000",
-            "line-width":0.5,
-            "line-dasharray":{
-              "stops":[
-                [
-                  15,
-                  [
-                    15,
-                    7.5
-                  ]
-                ],
-                [
-                  17,
-                  [
-                    30,
-                    15
-                  ]
-                ]
-              ]
-            },
-            "line-opacity":{
-              "stops":[
-                [
-                  14,
-                  0
-                ],
-                [
-                  15,
-                  1
-                ]
-              ]
-            }
+          "id": "citymap-street-centerlines-symbol",
+          "type": "symbol",
+          "source": "digital-citymap",
+          "source-layer": "street-centerlines",
+          "paint": {},
+          "layout": {
+            "text-field": "{streetname} - ({streetwidth} ft)",
+            "text-keep-upright": true,
+            "symbol-placement": "line",
+            "text-size": 12
           }
         }
       }

--- a/public/layer-groups.json
+++ b/public/layer-groups.json
@@ -467,18 +467,26 @@
     },
     "layers":[
       {
-        "id": "citymap-street-centerlines",
+        "id": "citymap-street-centerlines-symbol",
         "style":{
           "id": "citymap-street-centerlines-symbol",
           "type": "symbol",
           "source": "digital-citymap",
           "source-layer": "street-centerlines",
-          "paint": {},
           "layout": {
             "text-field": "{streetname} - ({streetwidth} ft)",
             "text-keep-upright": true,
             "symbol-placement": "line",
-            "text-size": 12
+            "text-size": 12  },
+          "paint": {
+            "text-color": "rgba(37, 37, 37, 1)",
+            "text-halo-color": "#fff",
+            "text-translate": [
+              0,
+              0
+            ],
+            "text-halo-width": 2,
+            "text-halo-blur": 1
           }
         }
       }

--- a/public/sources.json
+++ b/public/sources.json
@@ -20,11 +20,11 @@
 			},
 			{
 				"id": "street-centerlines",
-				"sql": "SELECT the_geom_webmercator FROM citymap_streetcenterlines_v0"
+				"sql": "SELECT the_geom_webmercator, official_s AS streetname, streetwidt AS streetwidth FROM citymap_streetcenterlines_v0"
 			},
 			{
 				"id": "citymap",
-				"sql": "SELECT the_geom_webmercator FROM citymap_citymap_v0"
+				"sql": "SELECT the_geom_webmercator, type FROM citymap_citymap_v0"
 			},
 			{
 				"id": "name-changes-points",


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR adds several new layers, and modifies symbology of existing layers.

Changes Proposed:
- New styles for pierhead and bulkhead lines (Closes #40)
- New layers for record streets, street treatments, underpasses/tunnels, non-zoning-boundary lines, unmapped streets (Closes #34)
- Add street name labels
