### PR TITLE
View this area in ZoLa

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -65,6 +65,13 @@ export default class ApplicationController extends ParachuteController {
     };
   }
 
+  // TODO: Change once ZoLa preserves map pan/zoom state w/ query params
+  @computed('lat', 'lng', 'zoom')
+  get mapLatLngZoomHash() {
+    const { lat, lng, zoom } = this.getProperties('lat', 'lng', 'zoom');
+    return `#${zoom}/${lng}/${lat}`;
+  }
+
   @argument
   popupLocation = {
     lng: 0,
@@ -105,17 +112,18 @@ export default class ApplicationController extends ParachuteController {
     this.set('map', map);
 
     const navigationControl = new mapboxgl.NavigationControl();
+    map.addControl(navigationControl, 'top-left');
+
     const geoLocateControl = new mapboxgl.GeolocateControl({
       positionOptions: {
         enableHighAccuracy: true,
       },
       trackUserLocation: true,
     });
-    const scaleControl = new mapboxgl.ScaleControl({ unit: 'imperial' });
-
-    map.addControl(navigationControl, 'top-left');
-    map.addControl(scaleControl, 'bottom-left');
     map.addControl(geoLocateControl, 'top-left');
+
+    const scaleControl = new mapboxgl.ScaleControl({ unit: 'imperial' });
+    map.addControl(scaleControl, 'bottom-left');
 
     const basemapLayersToHide = [
       'highway_path',

--- a/app/styles/modules/_m-maps.scss
+++ b/app/styles/modules/_m-maps.scss
@@ -122,3 +122,21 @@
 .mapboxgl-user-location-dot {
   box-sizing: initial;
 }
+
+// "See this area in ZoLa" button
+.zola-map-area-button {
+  @include button(false, $white, #F2F2F2, $primary-color, solid);
+
+  position: absolute;
+  z-index: 2;
+  top: 10px;
+  right: 10px;
+  padding: 0.5em 0.75em;
+  font-size: rem-calc(11);
+  border-radius: 4px;
+  box-shadow: 0 0 0 2px rgba(0,0,0,0.1);
+
+  small {
+    display: block;
+  }
+}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -29,6 +29,10 @@
       {{map.on 'zoomend' (action 'handleZoomend')}}
       {{map.on 'dragend' (action 'handleDragend')}}
     {{/labs-map}}
+    <a class="zola-map-area-button" href="https://zola.planning.nyc.gov/{{mapLatLngZoomHash}}" target="_blank" rel="noopener">
+      <strong>View <span class="show-for-medium">this area</span> in ZoLa</strong>
+      <small class="show-for-medium">NYC’s Zoning &amp; Land Use Map</small>
+    </a>
   </div>
 
   <div class="layer-menu cell large-order-1">


### PR DESCRIPTION
This PR adds a button to the top-right corner of the map, which opens ZoLa in a new window with the same lat/lng/zoom being viewed in City Map. 

Closes #11 