### PR TITLE
Bug: prevent ZoLa button overlapping content close button

### DIFF
--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -62,11 +62,15 @@ body {
 .layer-menu {
   background-color: $light-gray;
   z-index: 2;
+  min-height: calc(50vh - 5rem);
 
   @include breakpoint(medium) {
+    min-height: none;
+    max-height: 50vh;
     height: 50vh;
     width: 15rem;
     box-shadow: -4px 0 0 rgba(0,0,0,0.1);
+    overflow: scroll;
   }
 
   @include breakpoint(large) {

--- a/app/styles/modules/_m-maps.scss
+++ b/app/styles/modules/_m-maps.scss
@@ -129,12 +129,19 @@
 
   position: absolute;
   z-index: 2;
-  top: 10px;
-  right: 10px;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
   padding: 0.5em 0.75em;
+  margin: 0;
   font-size: rem-calc(11);
-  border-radius: 4px;
+  border-radius: 4px 4px 0 0;
   box-shadow: 0 0 0 2px rgba(0,0,0,0.1);
+
+  @include breakpoint(medium only) {
+    left: 130px;
+    transform: none;
+  }
 
   small {
     display: block;


### PR DESCRIPTION
- Moves the ZoLa button to the bottom of the map, as to not collide with the content area's close button 
- Fixes layer menu scroll, height on medium screens