### PR TITLE
Filter uses model instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,11 @@ record.set('paint', { 'fill-color':'pink' });
 ```
 
 #### Change filtering
-*Does not work yet*
+For now, we need to use a helper method for this because updates aren't being triggered correctly yet.
 
-There is some issue with the data binding here that we are still working on. `map.setFilter` must be used instead.
+```javascript
+layerModelInstance.setFilter(['all', ['>=', 'effective', 100]]);
+```
 
 #### Map Styling
 

--- a/app/components/slider-filter.js
+++ b/app/components/slider-filter.js
@@ -13,10 +13,6 @@ const defaultStart = [-2082931200, 1518825600];
 export default class SliderFilterComponent extends Component {
   @required
   @argument
-  map;
-
-  @required
-  @argument
   layer;
 
   start = defaultStart
@@ -31,14 +27,8 @@ export default class SliderFilterComponent extends Component {
   @action
   sliderChanged([min, max]) {
     const filter = this.generateExpression(min, max);
-    const map = this.get('map');
-
-    // const layer = this.get('layer');
-    // layer.set('filter', filter);
-
-    // TODO: fix in ember-mapbox-gl, where filters do not trigger
-    // updates in the data
-    map.setFilter(this.get('layer.id'), filter); // <-- this works, but uses map directly
+    const layer = this.get('layer');
+    layer.setFilter(filter);
   }
 
   generateExpression(min, max) {

--- a/app/models/layer.js
+++ b/app/models/layer.js
@@ -4,12 +4,13 @@ import { attr, belongsTo } from 'ember-decorators/data';
 import { alias } from 'ember-decorators/object/computed';
 import { copy } from '@ember/object/internals';
 import { set } from '@ember/object';
+import { assign } from '@ember/polyfills';
 
 export default class LayerModel extends Model {
   constructor(...args) {
     super(...args);
-    this.delegateVisibility();
-    this.addObserver('visible', this, 'delegateVisibility');
+    this.inheritVisibility();
+    this.addObserver('visible', this, 'inheritVisibility');
   }
 
   @computed('style.{paint,layout,filter}')
@@ -33,7 +34,11 @@ export default class LayerModel extends Model {
 
   @alias('style.paint') paint;
 
-  delegateVisibility() {
+  setFilter(filter = []) {
+    this.set('style', assign({}, this.get('style'), { filter }));
+  }
+
+  inheritVisibility() {
     const visible = this.get('visible');
     const visibility = (visible ? 'visible' : 'none');
     const layout = copy(this.get('layout'));

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -64,7 +64,7 @@
         {{#layer-menu-item
           title=layerGroup.model.title
           active=amendments}}
-          {{slider-filter layer=model.amendmentsFill map=map}}
+          {{slider-filter layer=model.amendmentsFill}}
         {{/layer-menu-item}}
       {{/lookup-layer-group}}
 


### PR DESCRIPTION
Adds a method on the Layer model to manage filter updates. Use #setFilter on an instance of the layer model.
