### PR TITLE
Zoning Districts use fill, set explicit layer order (before)

### DIFF
--- a/app/models/layer.js
+++ b/app/models/layer.js
@@ -17,6 +17,10 @@ export default class LayerModel extends Model {
     return this.get('style');
   }
 
+  @attr('string', {
+    defaultValue: 'place_other',
+  }) before
+
   @belongsTo('layer-group') layerGroup
 
   @attr({

--- a/lib/labs-maps/addon/templates/components/labs-layers.hbs
+++ b/lib/labs-maps/addon/templates/components/labs-layers.hbs
@@ -3,24 +3,26 @@
 
   {{!-- if the layer is hightlightable or tooltipable, bind events --}}
   {{#if (or layerObject.highlightable layerObject.tooltipable)}}
-    {{mapbox-gl-on 'mousemove' layerObject.mapboxGlStyle.id (action 'handleLayerMouseMove') 
+    {{mapbox-gl-on 'mousemove' layerObject.mapboxGlStyle.id (action 'handleLayerMouseMove')
       eventSource=map}}
-    {{mapbox-gl-on 'mouseleave' layerObject.mapboxGlStyle.id (action 'handleLayerMouseLeave') 
+    {{mapbox-gl-on 'mouseleave' layerObject.mapboxGlStyle.id (action 'handleLayerMouseLeave')
       eventSource=map}}
   {{/if}}
 
-  {{mapbox-gl-on 'click' layerObject.mapboxGlStyle.id (action 'handleLayerMouseClick') 
+  {{mapbox-gl-on 'click' layerObject.mapboxGlStyle.id (action 'handleLayerMouseClick')
     eventSource=map}}
 
-  {{mapbox-gl-layer 
+  {{mapbox-gl-layer
       map=map
-      layer=layerObject.mapboxGlStyle}}
+      layer=layerObject.mapboxGlStyle
+      before=layerObject.before
+    }}
 
   {{!-- Backup - filter is not updating correctly, but it does when
   props are bound directly --}}
-  {{!--   {{mapbox-gl-layer 
+  {{!--   {{mapbox-gl-layer
         map=map
-        layer=(hash paint=layerObject.mapboxGlStyle.paint 
+        layer=(hash paint=layerObject.mapboxGlStyle.paint
                     layout=layerObject.mapboxGlStyle.layout
                     filter=layerObject.mapboxGlStyle.filter
                     type=layerObject.mapboxGlStyle.type
@@ -31,17 +33,17 @@
 
 {{!-- Highlighted Layer Handling --}}
 {{#if hoveredFeature}}
-  {{mapbox-gl-layer 
-    map=map 
+  {{mapbox-gl-layer
+    map=map
     layer=highlightedFeatureLayer}}
 {{/if}}
 
-{{yield (hash 
-  tooltip=(if hoveredFeature 
-    (component toolTipComponent 
-      feature=hoveredFeature 
-      layer=hoveredLayer 
-      top=mousePosition.y 
+{{yield (hash
+  tooltip=(if hoveredFeature
+    (component toolTipComponent
+      feature=hoveredFeature
+      layer=hoveredLayer
+      top=mousePosition.y
       left=mousePosition.x
     )
   )

--- a/public/layer-groups.json
+++ b/public/layer-groups.json
@@ -1,6 +1,251 @@
 [
 
   {
+    "id": "zoning-districts",
+    "title": "Zoning Districts",
+    "visible": false,
+    "titleTooltip": "A zoning district is a residential, commercial or manufac­turing area of the city within which zoning regulations govern land use and building bulk.",
+    "meta": {
+      "description": "NYC GIS Zoning Features March 2018, Bytes of the Big Apple",
+      "url": [
+        "https://www1.nyc.gov/site/planning/data-maps/open-data.page"
+      ],
+      "updated_at": "April 5th, 2018"
+    },
+    "layers": [
+      {
+        "style": {
+          "id": "zd-fill",
+          "type": "fill",
+          "source": "zoning",
+          "source-layer": "zoning-districts",
+          "paint": {
+            "fill-color": {
+              "property": "primaryzone",
+              "type": "categorical",
+              "stops": [
+                ["BP", "#808080"],
+                ["C1", "#ffa89c"],
+                ["C2", "#fd9a8f"],
+                ["C3", "#fa867c"],
+                ["C4", "#f76e67"],
+                ["C5", "#f2544e"],
+                ["C6", "#ee3a36"],
+                ["C7", "#ea2220"],
+                ["C8", "#e50000"],
+                ["M1", "#f3b3ff"],
+                ["M2", "#e187f3"],
+                ["M3", "#cf5ce6"],
+                ["PA", "#78D271"],
+                ["R1", "#fff8a6"],
+                ["R2", "#fff7a6"],
+                ["R3", "#fff797"],
+                ["R4", "#fff584"],
+                ["R5", "#fff36c"],
+                ["R6", "#fff153"],
+                ["R7", "#ffee39"],
+                ["R8", "#ffec22"],
+                ["R9", "#ffeb0e"],
+                ["R10", "#ffea00"]
+              ]
+            },
+            "fill-opacity": {
+              "stops": [
+                [12, 0.5],
+                [14, 0.3]
+              ]
+            },
+            "fill-antialias": true
+          }
+        }
+      },
+      {
+        "before": "place_country_major",
+        "style": {
+          "id": "zd_labels",
+          "type": "symbol",
+          "source": "zoning",
+          "source-layer": "zoning-districts",
+          "layout": {
+            "symbol-placement": "point",
+            "text-field": "{zonedist}",
+            "text-size": {
+              "stops": [
+                [
+                  10,
+                  8
+                ],
+                [
+                  14,
+                  16
+                ]
+              ]
+            }
+          },
+          "paint": {
+            "text-color": {
+              "stops": [
+                [15, "#626262"],
+                [16, "#444"]
+              ]
+            },
+            "text-halo-color": "#FFFFFF",
+            "text-halo-width": 2,
+            "text-halo-blur": 2,
+            "text-opacity": {
+              "stops": [
+                [12, 0],
+                [13, 1]
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+
+  {
+    "id": "special-purpose-districts",
+    "title": "Special Purpose Districts",
+    "titleTooltip": "The regulations for special purpose districts are designed to supplement and modify the underlying zoning in order to respond to distinctive neighborhoods with particular issues and goals",
+    "legendIcon": "polygon",
+    "legendColor": "#5E6633",
+    "meta": {
+      "description": "NYC GIS Zoning Features February 2018, Bytes of the Big Apple",
+      "url": [
+        "https://www1.nyc.gov/site/planning/data-maps/open-data.page"
+      ],
+      "updated_at": "5 March 2018"
+    },
+    "layers": [
+      {
+        "style": {
+          "id": "zoning-sp-line",
+          "type": "line",
+          "source": "zoning",
+          "source-layer": "special-purpose-districts",
+          "paint": {
+            "line-width": {
+              "stops": [
+                [
+                  11,
+                  1
+                ],
+                [
+                  12,
+                  3
+                ]
+              ]
+            },
+            "line-color": "#5E6633",
+            "line-dasharray": [
+              1,
+              1
+            ],
+            "line-opacity": 0.6
+          }
+        }
+      },
+      {
+        "style": {
+          "id": "zoning-sp-fill",
+          "type": "fill",
+          "source": "zoning",
+          "source-layer": "special-purpose-districts",
+          "paint": {
+            "fill-color": "#5E6633",
+            "fill-opacity": 0.2
+          }
+        }
+      }
+    ]
+  },
+
+  {
+    "id": "floodplain-efirm2007",
+    "title": "Effective Flood Insurance Rate Maps 2007",
+    "titleTooltip": "The Effective Flood Insurance Rate Maps (FIRMs), first adopted by New York City in 1983 and last updated in 2007, establish the floodplain currently subject to the National Flood Insurance Program purchase requirements.",
+    "meta": {
+      "description": "Effective Flood Insurance Rate Maps (FIRMs) data are available at FEMA Flood Map Service Center",
+      "url": [
+        "https://msc.fema.gov/portal"
+      ],
+      "updated_at": "September 2017"
+    },
+    "layers": [
+      {
+        "style": {
+          "id": "effective-flood-insurance-rate-2007",
+          "type": "fill",
+          "source": "floodplains",
+          "source-layer": "effective-flood-insurance-rate-2007",
+          "paint": {
+            "fill-color": {
+              "property": "fld_zone",
+              "type": "categorical",
+              "stops": [
+                [
+                  "V",
+                  "#0084a8"
+                ],
+                [
+                  "A",
+                  "#00a9e6"
+                ]
+              ]
+            },
+            "fill-opacity": 0.7
+          }
+        },
+        "highlightable": true,
+        "tooltipTemplate": "2007 {{fld_zone}} Zone"
+      }
+    ]
+  },
+
+  {
+    "id": "floodplain-pfirm2015",
+    "title": "Preliminary Flood Insurance Rate Maps 2015",
+    "titleTooltip": "Released in 2015 as part of a citywide flood map update, the Preliminary FIRMs establish the 1% annual chance floodplain. For building code and zoning purposes, the more expansive of the either the 2015 or 2007 maps is used.",
+    "meta": {
+      "description": "Flood Insurance Rate Data provided by FEMA",
+      "url": [
+        "http://www.region2coastal.com/view-flood-maps-data/view-preliminary-flood-map-data/"
+      ],
+      "updated_at": "September 2017"
+    },
+    "layers": [
+      {
+        "style": {
+          "id": "preliminary-flood-insurance-rate",
+          "type": "fill",
+          "source": "floodplains",
+          "source-layer": "preliminary-flood-insurance-rate",
+          "paint": {
+            "fill-color": {
+              "property": "fld_zone",
+              "type": "categorical",
+              "stops": [
+                [
+                  "V",
+                  "#0084a8"
+                ],
+                [
+                  "A",
+                  "#00a9e6"
+                ]
+              ]
+            },
+            "fill-opacity": 0.7
+          }
+        },
+        "highlightable": true,
+        "tooltipTemplate": "2015 {{fld_zone}} Zone"
+      }
+    ]
+  },
+
+  {
     "id": "pierhead-bulkhead-lines",
     "title": "Pierhead & Bulkhead Lines",
     "legendIcon": "admin-line",
@@ -80,6 +325,47 @@
           },
           "layout": {
             "line-cap": "round"
+          }
+        }
+      }
+    ]
+  },
+
+  {
+    "id": "arterials",
+    "title": "Arterial Highways & Major Streets",
+    "legendIcon": "admin-line",
+    "legendColor": "",
+    "visible": false,
+    "meta": {
+      "description": "NYC Department of City Planning Technical Review Division",
+      "updated_at": "6 April 2018"
+    },
+    "layers": [
+      {
+        "style": {
+          "id": "citymap-arterials-line",
+          "type": "line",
+          "source": "digital-citymap",
+          "source-layer": "arterials",
+          "paint": {
+            "line-color": "rgba(245, 147, 80, 1)",
+            "line-width": {
+              "stops": [
+                [
+                  10,
+                  1.5
+                ],
+                [
+                  14,
+                  10
+                ]
+              ]
+            },
+            "line-opacity": 0.3
+          },
+          "layout": {
+            "visibility": "visible"
           }
         }
       }
@@ -366,47 +652,6 @@
   },
 
   {
-    "id": "arterials",
-    "title": "Arterial Highways & Major Streets",
-    "legendIcon": "admin-line",
-    "legendColor": "",
-    "visible": false,
-    "meta": {
-      "description": "NYC Department of City Planning Technical Review Division",
-      "updated_at": "6 April 2018"
-    },
-    "layers": [
-      {
-        "style": {
-          "id": "citymap-arterials-line",
-          "type": "line",
-          "source": "digital-citymap",
-          "source-layer": "arterials",
-          "paint": {
-            "line-color": "rgba(245, 147, 80, 1)",
-            "line-width": {
-              "stops": [
-                [
-                  10,
-                  1.5
-                ],
-                [
-                  14,
-                  10
-                ]
-              ]
-            },
-            "line-opacity": 0.3
-          },
-          "layout": {
-            "visibility": "visible"
-          }
-        }
-      }
-    ]
-  },
-
-  {
     "id": "amendments",
     "title": "City Map Alterations",
     "legendIcon": "admin-line",
@@ -464,6 +709,7 @@
     },
     "layers": [
       {
+        "before": "place_country_major",
         "style": {
           "id": "citymap-street-centerlines-symbol",
           "type": "symbol",
@@ -580,100 +826,6 @@
   },
 
   {
-    "id": "zoning-districts",
-    "title": "Zoning Districts",
-    "visible": false,
-    "titleTooltip": "A zoning district is a residential, commercial or manufac­turing area of the city within which zoning regulations govern land use and building bulk.",
-    "meta": {
-      "description": "NYC GIS Zoning Features March 2018, Bytes of the Big Apple",
-      "url": [
-        "https://www1.nyc.gov/site/planning/data-maps/open-data.page"
-      ],
-      "updated_at": "April 5th, 2018"
-    },
-    "layers": [
-      {
-        "style": {
-          "id": "zd-lines",
-          "type": "line",
-          "source": "zoning",
-          "source-layer": "zoning-districts",
-          "paint": {
-            "line-opacity": 0.8,
-            "line-width": {
-              "stops": [
-                [
-                  13,
-                  1
-                ],
-                [
-                  14,
-                  3
-                ]
-              ]
-            },
-            "line-color": "rgba(255, 0, 5, 1)"
-          }
-        },
-        "before": "place_other"
-      },
-      {
-        "style": {
-          "id": "zd_labels",
-          "type": "symbol",
-          "source": "zoning",
-          "source-layer": "zoning-districts",
-          "layout": {
-            "symbol-placement": "point",
-            "text-field": "{zonedist}",
-            "text-size": {
-              "stops": [
-                [
-                  10,
-                  8
-                ],
-                [
-                  14,
-                  16
-                ]
-              ]
-            }
-          },
-          "paint": {
-            "text-color": {
-              "stops": [
-                [
-                  15,
-                  "rgba(255, 0, 5, 1)"
-                ],
-                [
-                  16,
-                  "rgba(255, 0, 5, 1)"
-                ]
-              ]
-            },
-            "text-halo-color": "#FFFFFF",
-            "text-halo-width": 2,
-            "text-halo-blur": 2,
-            "text-opacity": {
-              "stops": [
-                [
-                  12,
-                  0
-                ],
-                [
-                  13,
-                  1
-                ]
-              ]
-            }
-          }
-        }
-      }
-    ]
-  },
-
-  {
     "id": "commercial-overlays",
     "title": "Commercial Overlays",
     "titleTooltip": "A commercial overlay is a C1 or C2 district mapped within residential districts to serve local retail needs.",
@@ -727,6 +879,7 @@
         }
       },
       {
+        "before": "place_country_major",
         "style": {
           "id": "co_labels",
           "type": "symbol",
@@ -744,63 +897,6 @@
             "text-field": "{overlay}"
           },
           "minzoom": 14
-        }
-      }
-    ]
-  },
-
-  {
-    "id": "special-purpose-districts",
-    "title": "Special Purpose Districts",
-    "titleTooltip": "The regulations for special purpose districts are designed to supplement and modify the underlying zoning in order to respond to distinctive neighborhoods with particular issues and goals",
-    "legendIcon": "polygon",
-    "legendColor": "#5E6633",
-    "meta": {
-      "description": "NYC GIS Zoning Features February 2018, Bytes of the Big Apple",
-      "url": [
-        "https://www1.nyc.gov/site/planning/data-maps/open-data.page"
-      ],
-      "updated_at": "5 March 2018"
-    },
-    "layers": [
-      {
-        "style": {
-          "id": "zoning-sp-line",
-          "type": "line",
-          "source": "zoning",
-          "source-layer": "special-purpose-districts",
-          "paint": {
-            "line-width": {
-              "stops": [
-                [
-                  11,
-                  1
-                ],
-                [
-                  12,
-                  3
-                ]
-              ]
-            },
-            "line-color": "#5E6633",
-            "line-dasharray": [
-              1,
-              1
-            ],
-            "line-opacity": 0.6
-          }
-        }
-      },
-      {
-        "style": {
-          "id": "zoning-sp-fill",
-          "type": "fill",
-          "source": "zoning",
-          "source-layer": "special-purpose-districts",
-          "paint": {
-            "fill-color": "#5E6633",
-            "fill-opacity": 0.2
-          }
         }
       }
     ]
@@ -911,6 +1007,7 @@
         }
       },
       {
+        "before": "place_country_major",
         "style": {
           "id": "pluto-labels",
           "type": "symbol",
@@ -943,90 +1040,6 @@
             "text-halo-color": "rgba(152, 152, 152, 0)"
           }
         }
-      }
-    ]
-  },
-
-  {
-    "id": "floodplain-efirm2007",
-    "title": "Effective Flood Insurance Rate Maps 2007",
-    "titleTooltip": "The Effective Flood Insurance Rate Maps (FIRMs), first adopted by New York City in 1983 and last updated in 2007, establish the floodplain currently subject to the National Flood Insurance Program purchase requirements.",
-    "meta": {
-      "description": "Effective Flood Insurance Rate Maps (FIRMs) data are available at FEMA Flood Map Service Center",
-      "url": [
-        "https://msc.fema.gov/portal"
-      ],
-      "updated_at": "September 2017"
-    },
-    "layers": [
-      {
-        "style": {
-          "id": "effective-flood-insurance-rate-2007",
-          "type": "fill",
-          "source": "floodplains",
-          "source-layer": "effective-flood-insurance-rate-2007",
-          "paint": {
-            "fill-color": {
-              "property": "fld_zone",
-              "type": "categorical",
-              "stops": [
-                [
-                  "V",
-                  "#0084a8"
-                ],
-                [
-                  "A",
-                  "#00a9e6"
-                ]
-              ]
-            },
-            "fill-opacity": 0.7
-          }
-        },
-        "highlightable": true,
-        "tooltipTemplate": "2007 {{fld_zone}} Zone"
-      }
-    ]
-  },
-
-  {
-    "id": "floodplain-pfirm2015",
-    "title": "Preliminary Flood Insurance Rate Maps 2015",
-    "titleTooltip": "Released in 2015 as part of a citywide flood map update, the Preliminary FIRMs establish the 1% annual chance floodplain. For building code and zoning purposes, the more expansive of the either the 2015 or 2007 maps is used.",
-    "meta": {
-      "description": "Flood Insurance Rate Data provided by FEMA",
-      "url": [
-        "http://www.region2coastal.com/view-flood-maps-data/view-preliminary-flood-map-data/"
-      ],
-      "updated_at": "September 2017"
-    },
-    "layers": [
-      {
-        "style": {
-          "id": "preliminary-flood-insurance-rate",
-          "type": "fill",
-          "source": "floodplains",
-          "source-layer": "preliminary-flood-insurance-rate",
-          "paint": {
-            "fill-color": {
-              "property": "fld_zone",
-              "type": "categorical",
-              "stops": [
-                [
-                  "V",
-                  "#0084a8"
-                ],
-                [
-                  "A",
-                  "#00a9e6"
-                ]
-              ]
-            },
-            "fill-opacity": 0.7
-          }
-        },
-        "highlightable": true,
-        "tooltipTemplate": "2015 {{fld_zone}} Zone"
       }
     ]
   }


### PR DESCRIPTION
This PR: 
- Changes the style of Zoning Districts to use fill color instead of red lines, closes #81
- Adds a `before` property to `{{mapbox-gl-layer}}` explicitly putting all our custom layers before the basemap's label layers (`place_other`) 
- Reorders the layer group objects in `layer-groups.json`
- Sets explicit `before` properties on our custom label layers so that they're pulled out of the implicit layer groups ordering and above everything else