### PR TITLE
Show/hide of layer menu on small screens

### DIFF
--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -89,7 +89,7 @@ body {
 .layer-menu {
   background-color: $light-gray;
   z-index: 2;
-  min-height: calc(50vh - 8rem);
+  // min-height: calc(50vh - 8rem);
 
   @include breakpoint(medium) {
     min-height: none;
@@ -114,9 +114,12 @@ body {
 .route-index {
 
   @include breakpoint(small) {
-    .map-container,
+    .map-container {
+      height: calc(100vh - 14.25rem);
+    }
+
     .layer-menu {
-      height: calc(100vh - 12rem);
+      min-height: 6rem;
     }
   }
 
@@ -147,6 +150,10 @@ body {
   background-color: $body-background;
   text-align: right;
   padding: $global-margin $global-margin 0;
+
+  @include breakpoint(small only) {
+    margin-bottom: -$global-margin;
+  }
 
   @include breakpoint(medium down) {
     @include xy-cell-static(full,false,0);

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -36,7 +36,7 @@
     </a>
   </div>
 
-  <div class="layer-menu cell large-order-1">
+  <div class="layer-menu cell large-order-1 {{unless (eq currentRouteName 'index') 'show-for-medium'}}">
     {{!-- City Map Layers --}}
     {{#accordion-menu title='City Map Layers'}}
       {{#lookup-layer-group for='citymap' as |layerGroup|}}


### PR DESCRIPTION
This PR shows the layer menu on small screens only when you're on the index route. If you have a page open (e.g. About), you must close the page to show the layer menu. This is a simplification of how the ZoLa mobile layer palette works, as its "Edit Map Layers" toggle button unnecessarily pushes content further down the page. To simplify on small screens, the index route is for exploring the map & layers, while the page routes are primarily for the page content. Closes #62 