### PR TITLE
Map resize on route change

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,6 +1,8 @@
 import Route from '@ember/routing/route';
 import { hash } from 'rsvp';
 import normalizeCartoVectors from 'carto-promises-utility/utils/normalize-carto-vectors';
+import { action } from '@ember-decorators/object';
+import { next } from '@ember/runloop';
 
 export default class ApplicationRoute extends Route {
   model = async function() {
@@ -18,6 +20,13 @@ export default class ApplicationRoute extends Route {
       layers,
       layerGroups,
       amendmentsFill,
+    });
+  }
+
+  @action
+  didTransition() {
+    next(function() {
+      window.dispatchEvent(new Event('resize'));
     });
   }
 }


### PR DESCRIPTION
This PR adds a window resize event on route transitions so that the map resizes appropriately when the content area is opened/closed. Closes #50 