### PR TITLE
fix search results positioning for med screens

### DIFF
--- a/app/styles/modules/_m-search.scss
+++ b/app/styles/modules/_m-search.scss
@@ -43,22 +43,38 @@
   top: 100%;
   right: auto;
   bottom: auto;
-  left: -200%; // hide by default, show with .focused
+  left: -200vw; // hide by default
   box-shadow: 0 2px 0 rgba(0,0,0,0.1);
   opacity: 0;
   transition: opacity 0.5s, left 0;
   transition-delay: 0.2s;
 
-  @include breakpoint(large) {
-    width: 22rem;
-    box-shadow: 4px 4px 0 rgba(0,0,0,0.1);
-    padding: 0 rem-calc(6) rem-calc(6);
-    max-height: calc(100vh - 9.375rem);
-    overflow: auto;
+  @include breakpoint(medium only) {
+    // hide to the right instead of left
+    left: auto;
+    right: -200vw;
   }
 
+  @include breakpoint(medium) {
+    width: 22rem;
+    box-shadow: -4px 4px 0 rgba(0,0,0,0.1);
+    max-height: calc(100vh - 10rem);
+    overflow: auto;
+    padding: 0 rem-calc(6) rem-calc(6);
+  }
+
+  @include breakpoint(large) {
+    box-shadow: 4px 4px 0 rgba(0,0,0,0.1);
+  }
+
+  // Only show results when .focused
   &.focused {
     left: 0;
+
+    @include breakpoint(medium only) {
+      left: auto;
+      right: 0;
+    }
   }
 
   &.has-results {


### PR DESCRIPTION
This PR fixes a bug with search results positioning on medium-sized screens while search is unfocused (which was introduced because the layout for medium screens is slightly different than ZoLa). 

Closes #103. 

![image](https://user-images.githubusercontent.com/409279/38939359-c27f850c-42f5-11e8-8f7c-75719682ee82.png)