### PR TITLE
prevent streetwidth SQL and template from showing na ft

### DIFF
--- a/public/layer-groups.json
+++ b/public/layer-groups.json
@@ -716,7 +716,7 @@
           "source": "digital-citymap",
           "source-layer": "street-centerlines",
           "layout": {
-            "text-field": "{streetname} - ({streetwidth} ft)",
+            "text-field": "{streetname}{streetwidth}",
             "text-keep-upright": true,
             "symbol-placement": "line",
             "text-size": 12

--- a/public/sources.json
+++ b/public/sources.json
@@ -1,75 +1,75 @@
 [
-	{
-		"id": "digital-citymap",
-		"type": "cartovector",
-		"source-layers": [{
-				"id": "bulkhead-lines",
-				"sql": "SELECT the_geom_webmercator FROM citymap_bulkheadlines_v0"
-			},
-			{
-				"id": "arterials",
-				"sql": "SELECT the_geom_webmercator FROM citymap_arterials_v0"
-			},
-			{
-				"id": "pierhead-lines",
-				"sql": "SELECT the_geom_webmercator FROM citymap_pierheadlines_v0"
-			},
-			{
-				"id": "amendments",
-				"sql": "SELECT the_geom_webmercator, cartodb_id as id, altmappdf, extract(epoch from effective) as effective FROM citymap_amendments_v0 WHERE effective IS NOT NULL"
-			},
-			{
-				"id": "street-centerlines",
-				"sql": "SELECT the_geom_webmercator, official_s AS streetname, streetwidt AS streetwidth FROM citymap_streetcenterlines_v0"
-			},
-			{
-				"id": "citymap",
-				"sql": "SELECT the_geom_webmercator, type FROM citymap_citymap_v0"
-			},
-			{
-				"id": "name-changes-points",
-				"sql": "SELECT the_geom_webmercator FROM citymap_streetnamechanges_points_v0"
-			},
-			{
-				"id": "name-changes-lines",
-				"sql": "SELECT the_geom_webmercator FROM citymap_streetnamechanges_streets_v0"
-			},
-			{
-				"id": "name-changes-areas",
-				"sql": "SELECT the_geom_webmercator FROM citymap_streetnamechanges_areas_v0"
-			}
-		]
-	},
-	{
-	  "id": "zoning",
-	  "type": "cartovector",
-	  "source-layers": [
-    	{
-	      "id": "zoning-districts",
-	      "sql": "SELECT *, CASE WHEN SUBSTRING(zonedist, 3, 1) = '-' THEN LEFT(zonedist, 2) WHEN SUBSTRING(zonedist, 3, 1) ~ E'[A-Z]' THEN LEFT(zonedist, 2) WHEN SUBSTRING(zonedist, 3, 1) ~ E'[0-9]' THEN LEFT(zonedist, 3) ELSE zonedist END as primaryzone FROM zoning_districts_v201803"
-	    },
-			{
-				"id": "special-purpose-districts",
-				"sql": "SELECT the_geom_webmercator, cartodb_id, sdlbl, sdname FROM special_purpose_districts_v201803"
-			},
-			{
-				"id": "commercial-overlays",
-				"sql": "SELECT * FROM commercial_overlays_v201803"
-			}
-	  ]
-	},
-	{
-	   "id": "pluto",
-	   "type": "cartovector",
-	   "minzoom": 12,
-	   "source-layers": [
-	      {
-	         "id": "pluto",
-	         "sql": "SELECT the_geom_webmercator, bbl, lot, landuse, address FROM mappluto_v1711"
-	      }
-	   ]
-	},
-	{
+  {
+    "id": "digital-citymap",
+    "type": "cartovector",
+    "source-layers": [{
+        "id": "bulkhead-lines",
+        "sql": "SELECT the_geom_webmercator FROM citymap_bulkheadlines_v0"
+      },
+      {
+        "id": "arterials",
+        "sql": "SELECT the_geom_webmercator FROM citymap_arterials_v0"
+      },
+      {
+        "id": "pierhead-lines",
+        "sql": "SELECT the_geom_webmercator FROM citymap_pierheadlines_v0"
+      },
+      {
+        "id": "amendments",
+        "sql": "SELECT the_geom_webmercator, cartodb_id as id, altmappdf, extract(epoch from effective) as effective FROM citymap_amendments_v0 WHERE effective IS NOT NULL"
+      },
+      {
+        "id": "street-centerlines",
+        "sql": "SELECT the_geom_webmercator, official_s AS streetname, COALESCE('   (' || streetwidt || ' ft)') AS streetwidth FROM citymap_streetcenterlines_v0"
+      },
+      {
+        "id": "citymap",
+        "sql": "SELECT the_geom_webmercator, type FROM citymap_citymap_v0"
+      },
+      {
+        "id": "name-changes-points",
+        "sql": "SELECT the_geom_webmercator FROM citymap_streetnamechanges_points_v0"
+      },
+      {
+        "id": "name-changes-lines",
+        "sql": "SELECT the_geom_webmercator FROM citymap_streetnamechanges_streets_v0"
+      },
+      {
+        "id": "name-changes-areas",
+        "sql": "SELECT the_geom_webmercator FROM citymap_streetnamechanges_areas_v0"
+      }
+    ]
+  },
+  {
+    "id": "zoning",
+    "type": "cartovector",
+    "source-layers": [
+      {
+        "id": "zoning-districts",
+        "sql": "SELECT *, CASE WHEN SUBSTRING(zonedist, 3, 1) = '-' THEN LEFT(zonedist, 2) WHEN SUBSTRING(zonedist, 3, 1) ~ E'[A-Z]' THEN LEFT(zonedist, 2) WHEN SUBSTRING(zonedist, 3, 1) ~ E'[0-9]' THEN LEFT(zonedist, 3) ELSE zonedist END as primaryzone FROM zoning_districts_v201803"
+      },
+      {
+        "id": "special-purpose-districts",
+        "sql": "SELECT the_geom_webmercator, cartodb_id, sdlbl, sdname FROM special_purpose_districts_v201803"
+      },
+      {
+        "id": "commercial-overlays",
+        "sql": "SELECT * FROM commercial_overlays_v201803"
+      }
+    ]
+  },
+  {
+     "id": "pluto",
+     "type": "cartovector",
+     "minzoom": 12,
+     "source-layers": [
+        {
+           "id": "pluto",
+           "sql": "SELECT the_geom_webmercator, bbl, lot, landuse, address FROM mappluto_v1711"
+        }
+     ]
+  },
+  {
     "id": "floodplains",
     "type": "cartovector",
     "source-layers": [
@@ -77,11 +77,11 @@
         "id": "effective-flood-insurance-rate-2007",
         "sql": "SELECT the_geom_webmercator, CASE WHEN fld_zone IN ('A', 'A0', 'AE') THEN 'A' WHEN fld_zone = 'VE' THEN 'V' END as fld_zone FROM floodplain_firm2007_v0 WHERE fld_zone IN ('A', 'A0', 'AE') OR fld_zone = 'VE'"
       },
-			{
-	      "id": "preliminary-flood-insurance-rate",
-	      "sql": "SELECT the_geom_webmercator, CASE WHEN fld_zone IN ('A', 'A0', 'AE') THEN 'A' WHEN fld_zone = 'VE' THEN 'V' WHEN fld_zone = '0.2 PCT ANNUAL CHANCE FLOOD HAZARD' THEN 'Shaded X' END as fld_zone FROM floodplain_pfirm2015_v0 WHERE fld_zone IN ('A', 'A0', 'AE') OR fld_zone = 'VE' "
-    	}
+      {
+        "id": "preliminary-flood-insurance-rate",
+        "sql": "SELECT the_geom_webmercator, CASE WHEN fld_zone IN ('A', 'A0', 'AE') THEN 'A' WHEN fld_zone = 'VE' THEN 'V' WHEN fld_zone = '0.2 PCT ANNUAL CHANCE FLOOD HAZARD' THEN 'Shaded X' END as fld_zone FROM floodplain_pfirm2015_v0 WHERE fld_zone IN ('A', 'A0', 'AE') OR fld_zone = 'VE' "
+      }
     ]
-	}
+  }
 
 ]


### PR DESCRIPTION
This PR removes the "(" prefix and "ft)" suffix which wrap the street width in the JSON mustache template, moving that logic to the SQL. This prevents null widths from showing "( ft)".

#### Before 
![image](https://user-images.githubusercontent.com/409279/38954591-0ad19852-4320-11e8-86ea-205cc1780fae.png)

^ Note Brooklyn Bridge

#### After
![image](https://user-images.githubusercontent.com/409279/38954603-11fb46e6-4320-11e8-864e-4118d62d741c.png)


Note: Some rows actually contain the word "Unknown" and are not null (see Anne Street above). So this PR does not take care of "(Unknown ft)". Should these also be null? Sometimes the work "Unknown" is used along with other measurements. 

<img src="https://user-images.githubusercontent.com/409279/38954692-589a6546-4320-11e8-82b6-26e477494320.png" width=230>

If this column is going to be a string, not a number, perhaps it should also contain the unit of measure. 

Closes #90 