### PR TITLE
72 tooltip on hover

### DIFF
--- a/app/components/tooltip-renderer.js
+++ b/app/components/tooltip-renderer.js
@@ -1,0 +1,20 @@
+import Component from '@ember/component';
+import { computed } from '@ember-decorators/object';
+import { argument } from '@ember-decorators/argument';
+import mustache from 'npm:mustache';
+
+export default class TooltipRenderer extends Component {
+  @computed('feature', 'template')
+  get renderedText() {
+    const properties = this.get('feature.properties');
+    const template = this.get('template');
+
+    return mustache.render(template, properties);
+  }
+
+  @argument
+  feature = {}
+
+  @argument
+  template = ''
+}

--- a/app/models/layer-group.js
+++ b/app/models/layer-group.js
@@ -12,7 +12,6 @@ export default class LayerGroupModel extends Model {
 
   @attr('boolean') visible = true
   @attr('boolean') highlightable = false
-  @attr('boolean') tooltipable = false
 
   @mapBy('layers', 'style') layerIds
 }

--- a/app/models/layer.js
+++ b/app/models/layer.js
@@ -13,6 +13,9 @@ export default class LayerModel extends Model {
     this.addObserver('visible', this, 'inheritVisibility');
   }
 
+  @attr('boolean') tooltipable = false
+  @attr('string') tooltipTemplate = ''
+
   @computed('style.{paint,layout,filter}')
   get mapboxGlStyle() {
     return this.get('style');

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -14,7 +14,7 @@
       {{#map.labs-layers
         model=model as |layers|}}
         {{#layers.tooltip as |tooltip|}}
-          {{tooltip.layer.id}}
+          {{tooltip-renderer feature=tooltip.feature template=tooltip.layer.tooltipTemplate}}
         {{/layers.tooltip}}
       {{/map.labs-layers}}
 

--- a/app/templates/components/tooltip-renderer.hbs
+++ b/app/templates/components/tooltip-renderer.hbs
@@ -1,0 +1,1 @@
+{{renderedText}}

--- a/public/layer-groups.json
+++ b/public/layer-groups.json
@@ -384,6 +384,8 @@
     },
     "layers": [
       {
+        "tooltipable": true,
+        "tooltipTemplate": "Type: {{type}}",
         "style": {
           "id": "citymap-mapped-streets-line",
           "type": "line",
@@ -419,6 +421,8 @@
         }
       },
       {
+        "tooltipable": true,
+        "tooltipTemplate": "Type: {{type}}",
         "style": {
           "id": "citymap-record-streets-line",
           "type": "line",
@@ -472,6 +476,8 @@
         }
       },
       {
+        "tooltipable": true,
+        "tooltipTemplate": "Type: {{type}}",
         "style": {
           "id": "citymap-street-treatments-line",
           "type": "line",
@@ -507,6 +513,8 @@
         }
       },
       {
+        "tooltipable": true,
+        "tooltipTemplate": "Type: {{type}}",
         "style": {
           "id": "citymap-underpass-tunnel-line",
           "type": "line",
@@ -560,6 +568,8 @@
         }
       },
       {
+        "tooltipable": true,
+        "tooltipTemplate": "Type: {{type}}",
         "style": {
           "id": "citymap-non-z-boundary-line",
           "type": "line",
@@ -607,6 +617,8 @@
         }
       },
       {
+        "tooltipable": true,
+        "tooltipTemplate": "Type: {{type}}",
         "style": {
           "id": "citymap-street-not-mapped-line",
           "type": "line",

--- a/tests/integration/components/tooltip-renderer-test.js
+++ b/tests/integration/components/tooltip-renderer-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | tooltip-renderer', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{tooltip-renderer}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#tooltip-renderer}}
+        template block text
+      {{/tooltip-renderer}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/tests/integration/components/tooltip-renderer-test.js
+++ b/tests/integration/components/tooltip-renderer-test.js
@@ -3,24 +3,25 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
+const feature = {
+  type: 'Feature',
+  geometry: {},
+  properties: {
+    foo: 'bar',
+  }
+};
+
+const template = 'The value of foo is {{foo}}';
+
 module('Integration | Component | tooltip-renderer', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
+  test('it renders a tooltipTemplate', async function(assert) {
+    this.set('feature', feature)
+    this.set('template', template)
 
-    await render(hbs`{{tooltip-renderer}}`);
+    await render(hbs`{{tooltip-renderer feature=feature template=template}}`);
 
-    assert.equal(this.element.textContent.trim(), '');
-
-    // Template block usage:
-    await render(hbs`
-      {{#tooltip-renderer}}
-        template block text
-      {{/tooltip-renderer}}
-    `);
-
-    assert.equal(this.element.textContent.trim(), 'template block text');
+    assert.equal(this.element.textContent.trim(), 'The value of foo is bar');
   });
 });


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR adds the same config-driven tooltip functionality we had in ZoLa, but does so by adding a new component `{{tooltip-renderer}}` which takes a geojson `feature` and a `template` as properties.

The template is a mustache.js template, like: `The tooltip value is {{somevalue}}`, which will look for the property `someValue` in the feature and render the template.

To use, layers (not layergroups!) need a `tooltipable` property and a `tooltipTemplate` property.  @allthesignals can you think of a reason why we should not just use the existence of `tooltipTemplate` to determine whether to show a tooltip?

Also, a test!  

Closes #72 
