### PR TITLE
85 legends

### DIFF
--- a/app/components/layer-menu-item.js
+++ b/app/components/layer-menu-item.js
@@ -19,6 +19,14 @@ export default class LayerMenuItemComponent extends Component {
 
   @argument
   @type('string')
+  legendIcon = '';
+
+  @argument
+  @type('string')
+  legendColor = '';
+
+  @argument
+  @type('string')
   tooltip = '';
 
   @argument

--- a/app/components/legend-icon.js
+++ b/app/components/legend-icon.js
@@ -1,0 +1,15 @@
+import Component from '@ember/component';
+import { argument } from '@ember-decorators/argument';
+import { type } from '@ember-decorators/argument/type';
+import { classNames } from 'ember-decorators/component';
+
+@classNames('legend-icon')
+export default class LegendIconComponent extends Component {
+  @argument
+  @type('string')
+  legendIcon = '';
+
+  @argument
+  @type('string')
+  legendColor = '';
+}

--- a/app/components/legend-icon.js
+++ b/app/components/legend-icon.js
@@ -1,10 +1,29 @@
 import Component from '@ember/component';
 import { argument } from '@ember-decorators/argument';
+import { computed } from '@ember-decorators/object';
 import { type } from '@ember-decorators/argument/type';
 import { classNames } from 'ember-decorators/component';
 
 @classNames('legend-icon')
 export default class LegendIconComponent extends Component {
+  @computed('legendColor')
+  get legendColorStyle() {
+    const color = this.get('legendColor');
+    return `color: ${color};`;
+  }
+
+  @computed('legendColor')
+  get legendBackgroundColorStyle() {
+    const color = this.get('legendColor');
+    return `background-color: ${color};`;
+  }
+
+  @computed('legendColor')
+  get legendBorderColorStyle() {
+    const color = this.get('legendColor');
+    return `border-color: ${color};`;
+  }
+
   @argument
   @type('string')
   legendIcon = '';

--- a/app/styles/modules/_m-layer-menu.scss
+++ b/app/styles/modules/_m-layer-menu.scss
@@ -49,9 +49,20 @@
 .legend {
   padding: 0 rem-calc(6);
   margin: 0;
+  color: $dark-gray;
 }
 
 .legend-item {
+}
+
+.polygon-stacked {
+  position: relative;
+
+  .fa + .fa {
+    position: absolute;
+    top: -0.2em;
+    left: 0.2em;
+  }
 }
 
 .legend-icon {

--- a/app/styles/modules/_m-layer-menu.scss
+++ b/app/styles/modules/_m-layer-menu.scss
@@ -55,6 +55,18 @@
 .legend-item {
 }
 
+.legend-icon {
+  height: 1.5em;
+  width: auto;
+  display: inline-block;
+  vertical-align: top;
+  margin: 0 rem-calc(2) 0 0;
+
+  &.line-array {
+    width: 2.5em;
+  }
+}
+
 .polygon-stacked {
   position: relative;
 
@@ -65,14 +77,27 @@
   }
 }
 
-.legend-icon {
-  height: 1.5em;
-  width: auto;
+.polygon-fill-dash {
+  opacity: 0.5;
   display: inline-block;
-  vertical-align: top;
-  margin: 0 rem-calc(2) 0 0;
+  width: 0.8em;
+  height: 0.8em;
+  position: relative;
 
-  &.line-array {
-    width: 2.5em;
+  .fill, .dash {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
+
+  .fill {
+    opacity: 0.3;
+  }
+
+  .dash {
+    border-width: 2px;
+    border-style: dotted;
   }
 }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -211,13 +211,13 @@
           active=name-changes}}
           <ul class="legend no-bullet">
             <li class="legend-item">
-               {{fa-icon 'circle' style="color:rgba(228, 72, 192, 1);transform:scale(0.6);"}} Streets
+              {{legend-icon legendColor='rgba(228, 72, 192, 1)' legendIcon='point'}} Streets
             </li>
             <li class="legend-item">
-               {{fa-icon 'minus' style="color:rgba(228, 72, 192, 0.5);"}} Intersections & Corners
+              {{legend-icon legendColor='rgba(228, 72, 192, 0.5)' legendIcon='line'}} Intersections & Corners
             </li>
             <li class="legend-item">
-               {{fa-icon 'square' style="color:rgba(228, 72, 192, 0.5);"}} Parks, Plazas, & Public Space
+              {{legend-icon legendColor='rgba(228, 72, 192, 0.5)' legendIcon='polygon'}} Parks, Plazas, & Public Space
             </li>
           </ul>
         {{/menu.menu-item}}
@@ -234,11 +234,11 @@
           tooltip=layerGroup.model.titleTooltip
           active=zoning-districts}}
           <ul class="legend no-bullet">
-            <li class="legend-item">{{fa-icon 'square' style="color:#ee3a36;opacity:0.8;"}} Commercial Districts</li>
-            <li class="legend-item">{{fa-icon 'square' style="color:#e187f3;opacity:0.8;"}} Manufacturing Districts</li>
-            <li class="legend-item">{{fa-icon 'square' style="color:#ffea00;opacity:0.8;"}} Residential Districts</li>
-            <li class="legend-item">{{fa-icon 'square' style="color:#78D271;opacity:0.8;"}} Parks</li>
-            <li class="legend-item">{{fa-icon 'square' style="color:#808080;opacity:0.8;"}} Battery Park City</li>
+            <li class="legend-item">{{legend-icon legendColor='rgba(238,58,54,0.8)' legendIcon='polygon'}} Commercial Districts</li>
+            <li class="legend-item">{{legend-icon legendColor='rgba(255,135,243,0.8)' legendIcon='polygon'}} Manufacturing Districts</li>
+            <li class="legend-item">{{legend-icon legendColor='rgba(255,234,0,0.8)' legendIcon='polygon'}} Residential Districts</li>
+            <li class="legend-item">{{legend-icon legendColor='rgba(120,210,113,0.8)' legendIcon='polygon'}} Parks</li>
+            <li class="legend-item">{{legend-icon legendColor='rgba(128,128,128,0.8)' legendIcon='polygon'}} Battery Park City</li>
           </ul>
         {{/menu.menu-item}}
       {{/lookup-layer-group}}
@@ -279,8 +279,8 @@
           tooltip=layerGroup.model.titleTooltip
           active=floodplain-pfirm2015}}
           <ul class="legend no-bullet">
-            <li class="legend-item">{{fa-icon 'square' style="color:#0084a8;opacity:0.7;"}} V Zone</li>
-            <li class="legend-item">{{fa-icon 'square' style="color:#00a9e6;opacity:0.7;"}} A Zone</li>
+            <li class="legend-item">{{legend-icon legendColor='rgba(0,132,168,0.7)' legendIcon='polygon'}} V Zone</li>
+            <li class="legend-item">{{legend-icon legendColor='rgba(0,169,230,0.7)' legendIcon='polygon'}} A Zone</li>
           </ul>
         {{/menu.menu-item}}
       {{/lookup-layer-group}}
@@ -291,8 +291,8 @@
           tooltip=layerGroup.model.titleTooltip
           active=floodplain-efirm2007}}
           <ul class="legend no-bullet">
-            <li class="legend-item">{{fa-icon 'square' style="color:#0084a8;opacity:0.7;"}} V Zone</li>
-            <li class="legend-item">{{fa-icon 'square' style="color:#00a9e6;opacity:0.7;"}} A Zone</li>
+            <li class="legend-item">{{legend-icon legendColor='rgba(0,132,168,0.7)' legendIcon='polygon'}} V Zone</li>
+            <li class="legend-item">{{legend-icon legendColor='rgba(0,169,230,0.7)' legendIcon='polygon'}} A Zone</li>
           </ul>
         {{/menu.menu-item}}
       {{/lookup-layer-group}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -246,6 +246,8 @@
       {{#lookup-layer-group for='commercial-overlays' as |layerGroup|}}
         {{#menu.menu-item
           title=layerGroup.model.title
+          legendColor=layerGroup.model.legendColor
+          legendIcon=layerGroup.model.legendIcon
           tooltip=layerGroup.model.titleTooltip
           active=commercial-overlays}}
         {{/menu.menu-item}}
@@ -254,6 +256,8 @@
       {{#lookup-layer-group for='special-purpose-districts' as |layerGroup|}}
         {{#menu.menu-item
           title=layerGroup.model.title
+          legendColor=layerGroup.model.legendColor
+          legendIcon=layerGroup.model.legendIcon
           tooltip=layerGroup.model.titleTooltip
           active=special-purpose-districts}}
         {{/menu.menu-item}}
@@ -263,6 +267,8 @@
         {{#menu.menu-item
           title=layerGroup.model.title
           tooltip=layerGroup.model.titleTooltip
+          legendColor=layerGroup.model.legendColor
+          legendIcon=layerGroup.model.legendIcon
           active=tax-lots}}
         {{/menu.menu-item}}
       {{/lookup-layer-group}}
@@ -272,6 +278,10 @@
           title=layerGroup.model.title
           tooltip=layerGroup.model.titleTooltip
           active=floodplain-pfirm2015}}
+          <ul class="legend no-bullet">
+            <li class="legend-item">{{fa-icon 'square' style="color:#0084a8;opacity:0.7;"}} V Zone</li>
+            <li class="legend-item">{{fa-icon 'square' style="color:#00a9e6;opacity:0.7;"}} A Zone</li>
+          </ul>
         {{/menu.menu-item}}
       {{/lookup-layer-group}}
 
@@ -280,6 +290,10 @@
           title=layerGroup.model.title
           tooltip=layerGroup.model.titleTooltip
           active=floodplain-efirm2007}}
+          <ul class="legend no-bullet">
+            <li class="legend-item">{{fa-icon 'square' style="color:#0084a8;opacity:0.7;"}} V Zone</li>
+            <li class="legend-item">{{fa-icon 'square' style="color:#00a9e6;opacity:0.7;"}} A Zone</li>
+          </ul>
         {{/menu.menu-item}}
       {{/lookup-layer-group}}
     {{/accordion-menu}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -211,10 +211,10 @@
           active=name-changes}}
           <ul class="legend no-bullet">
             <li class="legend-item">
-              {{legend-icon legendColor='rgba(228, 72, 192, 1)' legendIcon='point'}} Streets
+              {{legend-icon legendColor='rgba(228, 72, 192, 1)' legendIcon='point'}} Intersections & Corners
             </li>
             <li class="legend-item">
-              {{legend-icon legendColor='rgba(228, 72, 192, 0.5)' legendIcon='line'}} Intersections & Corners
+              {{legend-icon legendColor='rgba(228, 72, 192, 0.5)' legendIcon='line'}} Streets
             </li>
             <li class="legend-item">
               {{legend-icon legendColor='rgba(228, 72, 192, 0.5)' legendIcon='polygon'}} Parks, Plazas, & Public Space

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -197,6 +197,8 @@
       {{#lookup-layer-group for='arterials' as |layerGroup|}}
         {{#menu.menu-item
           title=layerGroup.model.title
+          legendColor=layerGroup.model.legendColor
+          legendIcon=layerGroup.model.legendIcon
           tooltip=layerGroup.model.titleTooltip
           active=arterials}}
         {{/menu.menu-item}}
@@ -207,6 +209,17 @@
           title=layerGroup.model.title
           tooltip=layerGroup.model.titleTooltip
           active=name-changes}}
+          <ul class="legend no-bullet">
+            <li class="legend-item">
+               {{fa-icon 'circle' style="color:rgba(228, 72, 192, 1);transform:scale(0.6);"}} Streets
+            </li>
+            <li class="legend-item">
+               {{fa-icon 'minus' style="color:rgba(228, 72, 192, 0.5);"}} Intersections & Corners
+            </li>
+            <li class="legend-item">
+               {{fa-icon 'square' style="color:rgba(228, 72, 192, 0.5);"}} Parks, Plazas, & Public Space
+            </li>
+          </ul>
         {{/menu.menu-item}}
       {{/lookup-layer-group}}
     {{/accordion-menu}}
@@ -220,6 +233,13 @@
           title=layerGroup.model.title
           tooltip=layerGroup.model.titleTooltip
           active=zoning-districts}}
+          <ul class="legend no-bullet">
+            <li class="legend-item">{{fa-icon 'square' style="color:#ee3a36;opacity:0.8;"}} Commercial Districts</li>
+            <li class="legend-item">{{fa-icon 'square' style="color:#e187f3;opacity:0.8;"}} Manufacturing Districts</li>
+            <li class="legend-item">{{fa-icon 'square' style="color:#ffea00;opacity:0.8;"}} Residential Districts</li>
+            <li class="legend-item">{{fa-icon 'square' style="color:#78D271;opacity:0.8;"}} Parks</li>
+            <li class="legend-item">{{fa-icon 'square' style="color:#808080;opacity:0.8;"}} Battery Park City</li>
+          </ul>
         {{/menu.menu-item}}
       {{/lookup-layer-group}}
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -97,7 +97,7 @@
       <div class="print-controls mapboxgl-ctrl mapboxgl-ctrl-group">
         <button {{action 'handlePrint'}} class="mapboxgl-ctrl-icon">{{fa-icon 'print'}}</button>
       </div>
-      
+
     {{/labs-map}}
 
   </div>
@@ -142,20 +142,6 @@
             </li>
             <li class="legend-item">
               <svg class="legend-icon line-array" height="10" width="17" viewBox="0 0 17 10" preserveAspectRatio="xMinYMid">
-                <g fill="none" stroke="#3278C8" stroke-width="1" stroke-linecap="round">
-                  <path stroke-dasharray="5,2.5,0,2,0,2.5" d="M0 5 l215 0" />
-                </g>
-              </svg> Pierhead
-            </li>
-            <li class="legend-item">
-              <svg class="legend-icon line-array" height="10" width="17" viewBox="0 0 17 10" preserveAspectRatio="xMinYMid">
-                <g fill="none" stroke="#3278C8" stroke-width="1" stroke-linecap="round">
-                  <path stroke-dasharray="5,2,0,1.5,0,1.5,0,2" d="M0 5 l215 0" />
-                </g>
-              </svg> Bulkhead
-            </li>
-            <li class="legend-item">
-              <svg class="legend-icon line-array" height="10" width="17" viewBox="0 0 17 10" preserveAspectRatio="xMinYMid">
                 <g fill="none" stroke="#1A961A" stroke-width="1" stroke-linecap="butt">
                   <path stroke-dasharray="5,1,2,1" d="M0 5 l215 0" />
                 </g>
@@ -178,12 +164,30 @@
           title=layerGroup.model.title
           tooltip=layerGroup.model.titleTooltip
           active=pierhead-bulkhead-lines}}
+          <ul class="legend no-bullet">
+            <li class="legend-item">
+              <svg class="legend-icon line-array" height="10" width="17" viewBox="0 0 17 10" preserveAspectRatio="xMinYMid">
+                <g fill="none" stroke="#3278C8" stroke-width="1" stroke-linecap="round">
+                  <path stroke-dasharray="5,2.5,0,2,0,2.5" d="M0 5 l215 0" />
+                </g>
+              </svg> Pierhead
+            </li>
+            <li class="legend-item">
+              <svg class="legend-icon line-array" height="10" width="17" viewBox="0 0 17 10" preserveAspectRatio="xMinYMid">
+                <g fill="none" stroke="#3278C8" stroke-width="1" stroke-linecap="round">
+                  <path stroke-dasharray="5,2,0,1.5,0,1.5,0,2" d="M0 5 l215 0" />
+                </g>
+              </svg> Bulkhead
+            </li>
+          </ul>
         {{/menu.menu-item}}
       {{/lookup-layer-group}}
 
       {{#lookup-layer-group for='amendments' as |layerGroup|}}
         {{#menu.menu-item
           title=layerGroup.model.title
+          legendColor=layerGroup.model.legendColor
+          legendIcon=layerGroup.model.legendIcon
           tooltip=layerGroup.model.titleTooltip
           active=amendments}}
           {{slider-filter layer=model.amendmentsFill}}

--- a/app/templates/components/layer-menu-item.hbs
+++ b/app/templates/components/layer-menu-item.hbs
@@ -10,6 +10,14 @@
       {{info-tooltip tip=tooltip}}
     {{/if}}
     {{title}}
+    {{#if (and legendColor active)}}
+      {{#if (eq legendIcon 'polygon-stacked')}}
+        <span class="polygon-stacked" style="color:{{legendColor}};">
+          {{fa-icon 'square'}}
+          {{fa-icon 'square'}}
+        </span>
+      {{/if}}
+    {{/if}}
   </span>
 </div>
 {{#if active}}

--- a/app/templates/components/layer-menu-item.hbs
+++ b/app/templates/components/layer-menu-item.hbs
@@ -24,6 +24,22 @@
           {{fa-icon 'minus'}}
         </span>
       {{/if}}
+      {{#if (eq legendIcon 'polygon')}}
+        <span class="polygon" style="color:{{legendColor}};">
+          {{fa-icon 'square'}}
+        </span>
+      {{/if}}
+      {{#if (eq legendIcon 'polygon-line')}}
+        <span class="polygon-line" style="color:{{legendColor}};">
+          {{fa-icon 'square-o'}}
+        </span>
+      {{/if}}
+      {{#if (eq legendIcon 'polygon-fill-dash')}}
+        <span class="polygon-fill-dash">
+          <span class="fill" style="background-color:{{legendColor}};"></span>
+          <span class="dash" style="border-color:{{legendColor}};"></span>
+        </span>
+      {{/if}}
     {{/if}}
 
   </span>

--- a/app/templates/components/layer-menu-item.hbs
+++ b/app/templates/components/layer-menu-item.hbs
@@ -12,33 +12,9 @@
 
     {{title}}
 
-    {{#if (and legendColor active)}}
-      {{#if (eq legendIcon 'polygon-stacked')}}
-        <span class="polygon-stacked" style="color:{{legendColor}};">
-          {{fa-icon 'square'}}
-          {{fa-icon 'square'}}
-        </span>
-      {{/if}}
-      {{#if (eq legendIcon 'line')}}
-        <span class="line" style="color:{{legendColor}};">
-          {{fa-icon 'minus'}}
-        </span>
-      {{/if}}
-      {{#if (eq legendIcon 'polygon')}}
-        <span class="polygon" style="color:{{legendColor}};">
-          {{fa-icon 'square'}}
-        </span>
-      {{/if}}
-      {{#if (eq legendIcon 'polygon-line')}}
-        <span class="polygon-line" style="color:{{legendColor}};">
-          {{fa-icon 'square-o'}}
-        </span>
-      {{/if}}
-      {{#if (eq legendIcon 'polygon-fill-dash')}}
-        <span class="polygon-fill-dash">
-          <span class="fill" style="background-color:{{legendColor}};"></span>
-          <span class="dash" style="border-color:{{legendColor}};"></span>
-        </span>
+    {{#if active}}
+      {{#if (and legendColor legendIcon)}}
+        {{legend-icon legendColor=legendColor legendIcon=legendIcon}}
       {{/if}}
     {{/if}}
 

--- a/app/templates/components/layer-menu-item.hbs
+++ b/app/templates/components/layer-menu-item.hbs
@@ -9,7 +9,9 @@
     {{#if tooltip}}
       {{info-tooltip tip=tooltip}}
     {{/if}}
+
     {{title}}
+
     {{#if (and legendColor active)}}
       {{#if (eq legendIcon 'polygon-stacked')}}
         <span class="polygon-stacked" style="color:{{legendColor}};">
@@ -17,7 +19,13 @@
           {{fa-icon 'square'}}
         </span>
       {{/if}}
+      {{#if (eq legendIcon 'line')}}
+        <span class="line" style="color:{{legendColor}};">
+          {{fa-icon 'minus'}}
+        </span>
+      {{/if}}
     {{/if}}
+
   </span>
 </div>
 {{#if active}}

--- a/app/templates/components/legend-icon.hbs
+++ b/app/templates/components/legend-icon.hbs
@@ -1,37 +1,37 @@
 {{#if (eq legendIcon 'line')}}
-  <span class="line" style="color:{{legendColor}};">
+  <span class="line" style={{legendColorStyle}}>
     {{fa-icon 'minus'}}
   </span>
 {{/if}}
 
 {{#if (eq legendIcon 'polygon')}}
-  <span class="polygon" style="color:{{legendColor}};">
+  <span class="polygon" style={{legendColorStyle}}>
     {{fa-icon 'square'}}
   </span>
 {{/if}}
 
 {{#if (eq legendIcon 'polygon-stacked')}}
-  <span class="polygon-stacked" style="color:{{legendColor}};">
+  <span class="polygon-stacked" style={{legendColorStyle}}>
     {{fa-icon 'square'}}
     {{fa-icon 'square'}}
   </span>
 {{/if}}
 
 {{#if (eq legendIcon 'polygon-line')}}
-  <span class="polygon-line" style="color:{{legendColor}};">
+  <span class="polygon-line" style={{legendColorStyle}}>
     {{fa-icon 'square-o'}}
   </span>
 {{/if}}
 
 {{#if (eq legendIcon 'polygon-fill-dash')}}
   <span class="polygon-fill-dash">
-    <span class="fill" style="background-color:{{legendColor}};"></span>
-    <span class="dash" style="border-color:{{legendColor}};"></span>
+    <span class="fill" style={{legendBackgroundColorStyle}}></span>
+    <span class="dash" style={{legendBorderColorStyle}}></span>
   </span>
 {{/if}}
 
 {{#if (eq legendIcon 'point')}}
-  <span class="point" style="color:{{legendColor}};">
+  <span class="point" style={{legendColorStyle}}>
     {{fa-icon 'circle' style="transform:scale(0.6);"}}
   </span>
 {{/if}}

--- a/app/templates/components/legend-icon.hbs
+++ b/app/templates/components/legend-icon.hbs
@@ -1,0 +1,39 @@
+{{#if (eq legendIcon 'line')}}
+  <span class="line" style="color:{{legendColor}};">
+    {{fa-icon 'minus'}}
+  </span>
+{{/if}}
+
+{{#if (eq legendIcon 'polygon')}}
+  <span class="polygon" style="color:{{legendColor}};">
+    {{fa-icon 'square'}}
+  </span>
+{{/if}}
+
+{{#if (eq legendIcon 'polygon-stacked')}}
+  <span class="polygon-stacked" style="color:{{legendColor}};">
+    {{fa-icon 'square'}}
+    {{fa-icon 'square'}}
+  </span>
+{{/if}}
+
+{{#if (eq legendIcon 'polygon-line')}}
+  <span class="polygon-line" style="color:{{legendColor}};">
+    {{fa-icon 'square-o'}}
+  </span>
+{{/if}}
+
+{{#if (eq legendIcon 'polygon-fill-dash')}}
+  <span class="polygon-fill-dash">
+    <span class="fill" style="background-color:{{legendColor}};"></span>
+    <span class="dash" style="border-color:{{legendColor}};"></span>
+  </span>
+{{/if}}
+
+{{#if (eq legendIcon 'point')}}
+  <span class="point" style="color:{{legendColor}};">
+    {{fa-icon 'circle' style="transform:scale(0.6);"}}
+  </span>
+{{/if}}
+
+{{!-- {{yield}} --}}

--- a/public/layer-groups.json
+++ b/public/layer-groups.json
@@ -336,7 +336,7 @@
     "title": "Arterial Highways & Major Streets",
     "titleTooltip": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
     "legendIcon": "line",
-    "legendColor": "rgba(245, 147, 80, 0.3)",
+    "legendColor": "rgba(245, 147, 80, 0.6)",
     "visible": false,
     "meta": {
       "description": "NYC Department of City Planning Technical Review Division",
@@ -350,7 +350,7 @@
           "source": "digital-citymap",
           "source-layer": "arterials",
           "paint": {
-            "line-color": "rgba(245, 147, 80, 0.3)",
+            "line-color": "rgba(245, 147, 80, 0.4)",
             "line-width": {
               "stops": [
                 [

--- a/public/layer-groups.json
+++ b/public/layer-groups.json
@@ -108,8 +108,8 @@
     "id": "special-purpose-districts",
     "title": "Special Purpose Districts",
     "titleTooltip": "The regulations for special purpose districts are designed to supplement and modify the underlying zoning in order to respond to distinctive neighborhoods with particular issues and goals",
-    "legendIcon": "polygon",
-    "legendColor": "#5E6633",
+    "legendIcon": "line",
+    "legendColor": "rgba(94,102,51, 0.6)",
     "meta": {
       "description": "NYC GIS Zoning Features February 2018, Bytes of the Big Apple",
       "url": [
@@ -137,12 +137,11 @@
                 ]
               ]
             },
-            "line-color": "#5E6633",
+            "line-color": "rgba(94,102,51, 0.6)",
             "line-dasharray": [
               1,
               1
-            ],
-            "line-opacity": 0.6
+            ]
           }
         }
       },
@@ -249,7 +248,7 @@
     "id": "pierhead-bulkhead-lines",
     "title": "Pierhead & Bulkhead Lines",
     "titleTooltip": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-    "legendIcon": "admin-line",
+    "legendIcon": "",
     "legendColor": "",
     "visible": true,
     "meta": {
@@ -336,8 +335,8 @@
     "id": "arterials",
     "title": "Arterial Highways & Major Streets",
     "titleTooltip": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-    "legendIcon": "admin-line",
-    "legendColor": "",
+    "legendIcon": "line",
+    "legendColor": "rgba(245, 147, 80, 0.3)",
     "visible": false,
     "meta": {
       "description": "NYC Department of City Planning Technical Review Division",
@@ -351,7 +350,7 @@
           "source": "digital-citymap",
           "source-layer": "arterials",
           "paint": {
-            "line-color": "rgba(245, 147, 80, 1)",
+            "line-color": "rgba(245, 147, 80, 0.3)",
             "line-width": {
               "stops": [
                 [
@@ -363,8 +362,7 @@
                   10
                 ]
               ]
-            },
-            "line-opacity": 0.3
+            }
           },
           "layout": {
             "visibility": "visible"
@@ -378,7 +376,7 @@
     "id": "citymap",
     "title": "Street Lines",
     "titleTooltip": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-    "legendIcon": "admin-line",
+    "legendIcon": "",
     "legendColor": "",
     "visible": true,
     "meta": {
@@ -670,10 +668,10 @@
     "id": "amendments",
     "title": "City Map Alterations",
     "titleTooltip": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-    "legendIcon": "admin-line",
-    "legendColor": "",
+    "legendIcon": "polygon-stacked",
+    "legendColor": "rgba(60, 133, 210, 0.4)",
     "visible": true,
-    "highlightable": false,
+    "highlightable": true,
     "meta": {
       "description": "NYC Department of City Planning Technical Review Division",
       "updated_at": "6 April 2018"
@@ -686,28 +684,9 @@
           "source": "digital-citymap",
           "source-layer": "amendments",
           "paint": {
-            "fill-opacity": 0.2,
-            "fill-color": "rgba(60, 133, 210, 1)"
+            "fill-color": "rgba(60, 133, 210, 0.2)"
           },
           "layout": {}
-        }
-      },
-      {
-        "style": {
-          "id": "citymap-amendments-hover",
-          "type": "fill",
-          "source": "digital-citymap",
-          "source-layer": "amendments",
-          "paint": {
-            "fill-color": "#627BC1",
-            "fill-opacity": 1
-          },
-          "layout": {},
-          "filter": [
-            "==",
-            "id",
-            ""
-          ]
         }
       }
     ]
@@ -717,7 +696,7 @@
     "id": "street-centerlines",
     "title": "Street Names",
     "titleTooltip": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-    "legendIcon": "admin-line",
+    "legendIcon": "",
     "legendColor": "",
     "visible": true,
     "meta": {
@@ -758,7 +737,7 @@
     "id": "name-changes",
     "title": "Local Law Names",
     "titleTooltip": "Local Law name changes to thoroughfares and public places from 2002-current",
-    "legendIcon": "admin-line",
+    "legendIcon": "",
     "legendColor": "",
     "visible": false,
     "meta": {

--- a/public/layer-groups.json
+++ b/public/layer-groups.json
@@ -108,8 +108,8 @@
     "id": "special-purpose-districts",
     "title": "Special Purpose Districts",
     "titleTooltip": "The regulations for special purpose districts are designed to supplement and modify the underlying zoning in order to respond to distinctive neighborhoods with particular issues and goals",
-    "legendIcon": "line",
-    "legendColor": "rgba(94,102,51, 0.6)",
+    "legendIcon": "polygon-fill-dash",
+    "legendColor": "rgba(94,102,51, 1)",
     "meta": {
       "description": "NYC GIS Zoning Features February 2018, Bytes of the Big Apple",
       "url": [
@@ -164,6 +164,8 @@
     "id": "floodplain-efirm2007",
     "title": "Effective Flood Insurance Rate Maps 2007",
     "titleTooltip": "The Effective Flood Insurance Rate Maps (FIRMs), first adopted by New York City in 1983 and last updated in 2007, establish the floodplain currently subject to the National Flood Insurance Program purchase requirements.",
+    "legendIcon": "polygon",
+    "legendColor": "#0084a8",
     "meta": {
       "description": "Effective Flood Insurance Rate Maps (FIRMs) data are available at FEMA Flood Map Service Center",
       "url": [
@@ -206,6 +208,8 @@
     "id": "floodplain-pfirm2015",
     "title": "Preliminary Flood Insurance Rate Maps 2015",
     "titleTooltip": "Released in 2015 as part of a citywide flood map update, the Preliminary FIRMs establish the 1% annual chance floodplain. For building code and zoning purposes, the more expansive of the either the 2015 or 2007 maps is used.",
+    "legendIcon": "polygon",
+    "legendColor": "#0084a8",
     "meta": {
       "description": "Flood Insurance Rate Data provided by FEMA",
       "url": [
@@ -827,6 +831,8 @@
     "id": "commercial-overlays",
     "title": "Commercial Overlays",
     "titleTooltip": "A commercial overlay is a C1 or C2 district mapped within residential districts to serve local retail needs.",
+    "legendIcon": "polygon-line",
+    "legendColor": "rgba(220, 10, 10, 1)",
     "visible": false,
     "meta": {
       "description": "NYC GIS Zoning Features February 2018, Bytes of the Big Apple",
@@ -904,6 +910,8 @@
     "id": "tax-lots",
     "title": "Tax Lots",
     "titleTooltip": "A tax lot is a parcel of land identified with a unique borough, block and lot number for property tax purposes.",
+    "legendIcon": "polygon-line",
+    "legendColor": "rgba(130, 130, 130, 1)",
     "meta": {
       "description": "MapPLUTO™ v17v1.1, Bytes of the Big Apple",
       "url": [

--- a/tests/integration/components/legend-icon-test.js
+++ b/tests/integration/components/legend-icon-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | legend-icon', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{legend-icon}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#legend-icon}}
+        template block text
+      {{/legend-icon}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/tests/integration/components/legend-icon-test.js
+++ b/tests/integration/components/legend-icon-test.js
@@ -1,26 +1,47 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | legend-icon', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
-
-    await render(hbs`{{legend-icon}}`);
-
-    assert.equal(this.element.textContent.trim(), '');
-
-    // Template block usage:
-    await render(hbs`
-      {{#legend-icon}}
-        template block text
-      {{/legend-icon}}
-    `);
-
-    assert.equal(this.element.textContent.trim(), 'template block text');
+  test('it renders a line icon', async function(assert) {
+    await render(hbs`{{legend-icon legendColor='#ff0000' legendIcon='line'}}`);
+    const icon = await find('.fa-minus');
+    assert.equal(!!icon, true);
   });
+
+  test('it renders a polygon icon', async function(assert) {
+    await render(hbs`{{legend-icon legendColor='#ff0000' legendIcon='polygon'}}`);
+    const icon = await find('.fa-square');
+    assert.equal(!!icon, true);
+  });
+
+  test('it renders a polygon-stacked icon', async function(assert) {
+    await render(hbs`{{legend-icon legendColor='#ff0000' legendIcon='polygon-stacked'}}`);
+    const icon = await find('.fa-square');
+    assert.equal(!!icon, true);
+  });
+
+  test('it renders a polygon-line icon', async function(assert) {
+    await render(hbs`{{legend-icon legendColor='#ff0000' legendIcon='polygon-line'}}`);
+    const icon = await find('.fa-square-o');
+    assert.equal(!!icon, true);
+  });
+
+  test('it renders a polygon-fill-dash icon', async function(assert) {
+    await render(hbs`{{legend-icon legendColor='#ff0000' legendIcon='polygon-fill-dash'}}`);
+    const fill = await find('.polygon-fill-dash .fill');
+    assert.equal(!!fill, true);
+    const dash = await find('.polygon-fill-dash .dash');
+    assert.equal(!!dash, true);
+  });
+
+  test('it renders a point icon', async function(assert) {
+    await render(hbs`{{legend-icon legendColor='#ff0000' legendIcon='point'}}`);
+    const icon = await find('.fa-circle');
+    assert.equal(!!icon, true);
+  });
+
 });


### PR DESCRIPTION
This PR adds a new `{{legend-icon}}` component, which is used a couple ways… 

The `legendIcon` and `legendColor` props can be passed from the layer config to `{{menu.menu-item}}` and a simple legend icon will be added to the whole layer group, next to the group title: 
```
        {{#menu.menu-item
          title=layerGroup.model.title
          legendColor=layerGroup.model.legendColor
          legendIcon=layerGroup.model.legendIcon
          tooltip=layerGroup.model.titleTooltip
          active=arterials}}
        {{/menu.menu-item}}
```

If `{{legend-icon}}` is used within the template block of `{{#menu.menu-item}}`, a more per-layer legend can be added to the group's expanded/active content: 
```
        {{#menu.menu-item
          title=layerGroup.model.title
          tooltip=layerGroup.model.titleTooltip
          active=floodplain-efirm2007}}
          <ul class="legend no-bullet">
            <li class="legend-item">{{legend-icon legendColor='rgba(0,132,168,0.7)' legendIcon='polygon'}} V Zone</li>
            <li class="legend-item">{{legend-icon legendColor='rgba(0,169,230,0.7)' legendIcon='polygon'}} A Zone</li>
          </ul>
        {{/menu.menu-item}}
```

The `legendIcon` prop can generate multiple types of icons: 
- line <img src="https://user-images.githubusercontent.com/409279/39206628-f7b12340-47cb-11e8-95ca-26e956db71cb.png" width=100 />
- polygon <img src="https://user-images.githubusercontent.com/409279/39206686-158ada1e-47cc-11e8-9caa-7ca8d6fadd67.png" width=150 />
- polygon-stacked <img src="https://user-images.githubusercontent.com/409279/39206409-55183380-47cb-11e8-9ac3-0d3da8941415.png" width=150 />
- polygon-line <img src="https://user-images.githubusercontent.com/409279/39206720-28c370d2-47cc-11e8-99dc-0ea8f065935c.png" width=150 />
- polygon-fill-dash <img src="https://user-images.githubusercontent.com/409279/39206736-3604e2d0-47cc-11e8-8f17-a809c75ba731.png" width=150 />
- point <img src="https://user-images.githubusercontent.com/409279/39206571-cc2aeab2-47cb-11e8-960d-81d6d15cae20.png" width=150 />



Closes #85.