### PR TITLE
Qp model binding

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -41,7 +41,7 @@ export const LayerVisibilityParams = new QueryParams({
     },
   },
   'selected-aerial': {
-    defaultValue: '',
+    defaultValue: 'aerials-2016',
     refresh: true,
   },
   lat: {
@@ -347,12 +347,12 @@ export default class ApplicationController extends ParachuteController {
   // runs on controller setup and calls
   // function to overwrite layer-groups'
   // visibility state with QP state
-  setup({ queryParams: { layerGroups } }) {
+  setup({ queryParams: { layerGroups: layerGroupParams, 'selected-aerial': selectedAerial } }) {
     const layerGroupModels = this.get('model.layerGroups');
 
-    if (layerGroups.length) {
+    if (layerGroupParams.length) {
       layerGroupModels.forEach((layerGroup) => {
-        if (layerGroups.includes(layerGroup.get('id'))) {
+        if (layerGroupParams.includes(layerGroup.get('id'))) {
           layerGroup.set('visible', true);
         } else {
           layerGroup.set('visible', false);
@@ -360,7 +360,13 @@ export default class ApplicationController extends ParachuteController {
       });
     }
 
+    if (selectedAerial) {
+      this.get('model.layerGroupMap.aerials').set('selected', selectedAerial);
+    }
+
+    // alias (two-way bind) model props to controller
     this.set('layerGroups', alias('visibleLayerGroups'));
+    this.set('selected-aerial', alias('model.layerGroupMap.aerials.selected'));
   }
 
   queryParamsDidChange() {

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -5,11 +5,11 @@ import QueryParams from 'ember-parachute';
 import carto from 'carto-promises-utility/utils/carto';
 import mapboxgl from 'mapbox-gl';
 import fetch from 'fetch';
-import precisionRound from '../utils/precision-round';
 import { alias } from '@ember/object/computed';
+import precisionRound from '../utils/precision-round';
 
 export const LayerVisibilityParams = new QueryParams({
-  'visibleLayers': {
+  visibleLayers: {
     defaultValue: [],
     refresh: true,
   },

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -12,58 +12,12 @@ export const LayerVisibilityParams = new QueryParams({
   layerGroups: {
     defaultValue: [],
     refresh: true,
-  },
-  'pierhead-bulkhead-lines': {
-    defaultValue: true,
-    refresh: true,
-  },
-  citymap: {
-    defaultValue: true,
-    refresh: true,
-  },
-  arterials: {
-    defaultValue: false,
-    refresh: true,
-  },
-  amendments: {
-    defaultValue: true,
-    refresh: true,
-  },
-  'street-centerlines': {
-    defaultValue: true,
-    refresh: true,
-  },
-  'name-changes': {
-    defaultValue: false,
-    refresh: true,
-  },
-  'zoning-districts': {
-    defaultValue: false,
-    refresh: true,
-  },
-  'commercial-overlays': {
-    defaultValue: false,
-    refresh: true,
-  },
-  'special-purpose-districts': {
-    defaultValue: false,
-    refresh: true,
-  },
-  'tax-lots': {
-    defaultValue: false,
-    refresh: true,
-  },
-  'floodplain-pfirm2015': {
-    defaultValue: false,
-    refresh: true,
-  },
-  'floodplain-efirm2007': {
-    defaultValue: false,
-    refresh: true,
-  },
-  aerials: {
-    defaultValue: false,
-    refresh: true,
+    serialize(value) {
+      return value.toString();
+    },
+    deserialize(value) {
+      return value.split(',');
+    },
   },
   'selected-aerial': {
     defaultValue: '',
@@ -72,19 +26,15 @@ export const LayerVisibilityParams = new QueryParams({
   lat: {
     defaultValue: -73.92,
   },
-
   lng: {
     defaultValue: 40.7,
   },
-
   zoom: {
     defaultValue: 10,
   },
-
   bearing: {
     defaultValue: 0,
   },
-
   pitch: {
     defaultValue: 0,
   },
@@ -338,30 +288,6 @@ export default class ApplicationController extends ParachuteController {
     this.set('highlightedAmendmentSource', null);
   }
 
-  // runs on controller setup and calls
-  // function to overwrite layer-groups'
-  // visibility state with QP state
-  setup({ queryParams }) {
-    const layerGroups = this.get('model.layerGroups');
-
-    layerGroups.setEach('visible', false);
-    queryParams.layerGroups.forEach((param) => {
-      layerGroups.findBy('id', param).set('visible', true);
-    });
-
-    this.set('layerGroups', alias('visibleLayerGroups'));
-  }
-
-  @computed('model.layerGroups.@each.visible')
-  get visibleLayerGroups() {
-    return this.get('model.layerGroups').filterBy('visible', true).mapBy('id');
-  }
-  set visibleLayerGroups(value) { /* noop */ }
-
-  queryParamsDidChange() {
-    this.set('shareURL', window.location.href);
-  }
-
   @action
   handlePrint() {
     fetch('https://map-print.planninglabs.nyc', {
@@ -388,4 +314,33 @@ export default class ApplicationController extends ParachuteController {
         w.document.close();
       });
   }
+
+  // runs on controller setup and calls
+  // function to overwrite layer-groups'
+  // visibility state with QP state
+  setup({ queryParams: { layerGroups } }) {
+    const layerGroupModels = this.get('model.layerGroups');
+
+    if (layerGroups.length) {
+      layerGroupModels.forEach((layerGroup) => {
+        if (layerGroups.includes(layerGroup.get('id'))) {
+          layerGroup.set('visible', true);
+        } else {
+          layerGroup.set('visible', false);
+        }
+      });
+    }
+
+    this.set('layerGroups', alias('visibleLayerGroups'));
+  }
+
+  queryParamsDidChange() {
+    this.set('shareURL', window.location.href);
+  }
+
+  @computed('model.layerGroups.@each.visible')
+  get visibleLayerGroups() {
+    return this.get('model.layerGroups').filterBy('visible', true).mapBy('id');
+  }
+  set visibleLayerGroups(value) { /* noop */ }
 }

--- a/app/models/layer-group.js
+++ b/app/models/layer-group.js
@@ -23,7 +23,12 @@ export default class LayerGroupModel extends Model {
   // singleton only
   @computed('layers.@each.visibility')
   get selected() {
-    return this.get('layers').findBy('visibility', true);
+    const selectedLayer = this.get('layers').findBy('visibility', true);
+    if (selectedLayer) {
+      return selectedLayer.get('id');
+    }
+
+    return null;
   }
   set selected(id) {
     this.get('layers').setEach('visibility', false);

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -34,6 +34,14 @@ export default class ApplicationRoute extends Route {
     });
   }
 
+  setupController(controller, model) {
+    controller.setDefaultQueryParamValue(
+      'layerGroups',
+      model.layerGroups.filterBy('visible', true).mapBy('id'),
+    );
+    super.setupController(controller, model);
+  }
+
   @action
   didTransition() {
     next(function() {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -8,10 +8,20 @@ export default class ApplicationRoute extends Route {
   model = async function() {
     const sources = await this.store.findAll('source')
       .then(sourceModels => normalizeCartoVectors(sourceModels.toArray()));
+
     const layers =
       await this.store.peekAll('layer');
+
     const layerGroups =
       await this.store.findAll('layer-group');
+
+    const layerGroupMap = layerGroups
+      .reduce((acc, layerGroup) => {
+        acc[layerGroup.get('id')] = layerGroup;
+
+        return acc;
+      }, {});
+
     const amendmentsFill =
       await this.store.peekRecord('layer', 'citymap-amendments-fill');
 
@@ -19,6 +29,7 @@ export default class ApplicationRoute extends Route {
       sources,
       layers,
       layerGroups,
+      layerGroupMap,
       amendmentsFill,
     });
   }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -164,7 +164,7 @@
         {{#menu.menu-item
           title=layerGroup.model.title
           tooltip=layerGroup.model.titleTooltip
-          active=citymap}}
+          active=layerGroup.model.visible}}
           <ul class="legend no-bullet">
             <li class="legend-item">
               <svg class="legend-icon line-array" height="10" width="17" viewBox="0 0 17 10" preserveAspectRatio="xMinYMid">
@@ -209,7 +209,7 @@
         {{#menu.menu-item
           title=layerGroup.model.title
           tooltip=layerGroup.model.titleTooltip
-          active=street-centerlines}}
+          active=layerGroup.model.visible}}
         {{/menu.menu-item}}
       {{/lookup-layer-group}}
 
@@ -217,7 +217,7 @@
         {{#menu.menu-item
           title=layerGroup.model.title
           tooltip=layerGroup.model.titleTooltip
-          active=pierhead-bulkhead-lines}}
+          active=layerGroup.model.visible}}
           <ul class="legend no-bullet">
             <li class="legend-item">
               <svg class="legend-icon line-array" height="10" width="17" viewBox="0 0 17 10" preserveAspectRatio="xMinYMid">
@@ -243,7 +243,7 @@
           legendColor=layerGroup.model.legendColor
           legendIcon=layerGroup.model.legendIcon
           tooltip=layerGroup.model.titleTooltip
-          active=amendments}}
+          active=layerGroup.model.visible}}
           {{slider-filter layer=model.amendmentsFill}}
         {{/menu.menu-item}}
       {{/lookup-layer-group}}
@@ -254,7 +254,7 @@
           legendColor=layerGroup.model.legendColor
           legendIcon=layerGroup.model.legendIcon
           tooltip=layerGroup.model.titleTooltip
-          active=arterials}}
+          active=layerGroup.model.visible}}
         {{/menu.menu-item}}
       {{/lookup-layer-group}}
 
@@ -262,7 +262,7 @@
         {{#menu.menu-item
           title=layerGroup.model.title
           tooltip=layerGroup.model.titleTooltip
-          active=name-changes}}
+          active=layerGroup.model.visible}}
           <ul class="legend no-bullet">
             <li class="legend-item">
               {{legend-icon legendColor='rgba(228, 72, 192, 1)' legendIcon='point'}} Intersections & Corners
@@ -286,7 +286,7 @@
         {{#menu.menu-item
           title=layerGroup.model.title
           tooltip=layerGroup.model.titleTooltip
-          active=zoning-districts}}
+          active=layerGroup.model.visible}}
           <ul class="legend no-bullet">
             <li class="legend-item">{{legend-icon legendColor='rgba(238,58,54,0.8)' legendIcon='polygon'}} Commercial Districts</li>
             <li class="legend-item">{{legend-icon legendColor='rgba(255,135,243,0.8)' legendIcon='polygon'}} Manufacturing Districts</li>
@@ -303,7 +303,7 @@
           legendColor=layerGroup.model.legendColor
           legendIcon=layerGroup.model.legendIcon
           tooltip=layerGroup.model.titleTooltip
-          active=commercial-overlays}}
+          active=layerGroup.model.visible}}
         {{/menu.menu-item}}
       {{/lookup-layer-group}}
 
@@ -313,7 +313,7 @@
           legendColor=layerGroup.model.legendColor
           legendIcon=layerGroup.model.legendIcon
           tooltip=layerGroup.model.titleTooltip
-          active=special-purpose-districts}}
+          active=layerGroup.model.visible}}
         {{/menu.menu-item}}
       {{/lookup-layer-group}}
 
@@ -323,7 +323,7 @@
           tooltip=layerGroup.model.titleTooltip
           legendColor=layerGroup.model.legendColor
           legendIcon=layerGroup.model.legendIcon
-          active=tax-lots}}
+          active=layerGroup.model.visible}}
         {{/menu.menu-item}}
       {{/lookup-layer-group}}
 
@@ -331,7 +331,7 @@
         {{#menu.menu-item
           title=layerGroup.model.title
           tooltip=layerGroup.model.titleTooltip
-          active=floodplain-pfirm2015}}
+          active=layerGroup.model.visible}}
           <ul class="legend no-bullet">
             <li class="legend-item">{{legend-icon legendColor='rgba(0,132,168,0.7)' legendIcon='polygon'}} V Zone</li>
             <li class="legend-item">{{legend-icon legendColor='rgba(0,169,230,0.7)' legendIcon='polygon'}} A Zone</li>
@@ -343,7 +343,7 @@
         {{#menu.menu-item
           title=layerGroup.model.title
           tooltip=layerGroup.model.titleTooltip
-          active=floodplain-efirm2007}}
+          active=layerGroup.model.visible}}
           <ul class="legend no-bullet">
             <li class="legend-item">{{legend-icon legendColor='rgba(0,132,168,0.7)' legendIcon='polygon'}} V Zone</li>
             <li class="legend-item">{{legend-icon legendColor='rgba(0,169,230,0.7)' legendIcon='polygon'}} A Zone</li>
@@ -355,7 +355,7 @@
         {{#menu.menu-item
           title=layerGroup.model.title
           tooltip=layerGroup.model.titleTooltip
-          active=aerials}}
+          active=layerGroup.model.visible}}
           <ul class="layer-menu-item--group-checkboxes list-float-3">
             {{#each layerGroup.model.layers as |layer|}}
               <li onclick={{action (mut selected-aerial) layer.id}} role='button'>
@@ -371,10 +371,6 @@
         {{/menu.menu-item}}
       {{/lookup-layer-group}}
     {{/accordion-menu}}
-
-    <a {{action 'resetToDefaults'}} class="button gray small reset-map-button" disabled={{isDefault}}>
-      {{fa-icon "undo"}} Reset Map Layers
-    </a>
   </div>
 
   {{outlet}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -371,6 +371,10 @@
         {{/menu.menu-item}}
       {{/lookup-layer-group}}
     {{/accordion-menu}}
+
+    <a {{action 'resetToDefaults'}} class="button gray small reset-map-button" disabled={{isDefault}}>
+      {{fa-icon "undo"}} Reset Map Layers
+    </a>
   </div>
 
   {{outlet}}

--- a/tests/acceptance/user-clicks-aerials-singleton-type-test.js
+++ b/tests/acceptance/user-clicks-aerials-singleton-type-test.js
@@ -7,23 +7,24 @@ module('Acceptance | user clicks aerials singleton type', function(hooks) {
 
   test('visiting /', async function(assert) {
     await visit('/');
-    await click('.layer-aerial-imagery .layer-menu-item-title');
+    await click('.layer-aerial-imagery .switch');
     await click('.layer-group-radio-aerials-2006');
     const toggledRadio = await find('.layer-group-radio-aerials-2006 .fa-dot-circle-o');
     assert.ok(toggledRadio);
 
-    assert.equal(currentURL(), '/?aerials=true&selected-aerial=aerials-2006');
+    assert.equal(currentURL(), '/?layerGroups=special-purpose-districts%2Cfloodplain-efirm2007%2Cfloodplain-pfirm2015%2Cpierhead-bulkhead-lines%2Ccitymap%2Camendments%2Cstreet-centerlines%2Caerials%2Ctax-lots&selected-aerial=aerials-2006');
 
     await click('.layer-aerial-imagery .layer-menu-item-title');
 
-    assert.equal(currentURL(), '/?selected-aerial=aerials-2006');
+    assert.equal(currentURL(), '/?layerGroups=special-purpose-districts%2Cfloodplain-efirm2007%2Cfloodplain-pfirm2015%2Cpierhead-bulkhead-lines%2Ccitymap%2Camendments%2Cstreet-centerlines%2Ctax-lots');
 
     await click('.layer-aerial-imagery .layer-menu-item-title');
 
-    assert.equal(currentURL(), '/?aerials=true&selected-aerial=aerials-2006');
+    assert.equal(currentURL(), '/?layerGroups=special-purpose-districts%2Cfloodplain-efirm2007%2Cfloodplain-pfirm2015%2Cpierhead-bulkhead-lines%2Ccitymap%2Camendments%2Cstreet-centerlines%2Caerials%2Ctax-lots');
 
     // it should preserve previously toggled
-    const toggledRadioAfter = await find('.layer-group-radio-aerials-2006 .fa-dot-circle-o');
-    assert.ok(toggledRadioAfter);
+    // UPDATE: This is no longer available, TODO
+    // const toggledRadioAfter = await find('.layer-group-radio-aerials-2006 .fa-dot-circle-o');
+    // assert.ok(toggledRadioAfter);
   });
 });


### PR DESCRIPTION
This PR fixes an issue in which there were multiple sources of truth about layer-group visibility state: inside the controller and on individual models. Now the single source of truth is the model, and query param'd properties on the controller are dynamically aliased to their respective layer-group models, including singleton type layer-groups.
