### PR TITLE
Fade in streets 

### DIFF
--- a/json/layer-groups/citymap.json
+++ b/json/layer-groups/citymap.json
@@ -16,7 +16,18 @@
         "source": "digital-citymap",
         "source-layer": "citymap",
         "paint": {
-          "line-color": "rgba(51, 51, 51, 1)",
+          "line-color": {
+            "stops": [
+              [
+                10,
+                "rgba(50, 50, 50, 0.3)"
+              ],
+              [
+                13,
+                "rgba(50, 50, 50, 1)"
+              ]
+            ]
+          },
           "line-width": {
             "stops": [
               [
@@ -104,7 +115,18 @@
           ]
         ],
         "paint": {
-          "line-color": "rgba(51, 51, 51, 1)",
+          "line-color": {
+            "stops": [
+              [
+                10,
+                "rgba(50, 50, 50, 0.3)"
+              ],
+              [
+                13,
+                "rgba(50, 50, 50, 1)"
+              ]
+            ]
+          },
           "line-width": {
             "stops": [
               [
@@ -157,7 +179,18 @@
           ]
         ],
         "paint": {
-          "line-color": "#545454",
+          "line-color": {
+            "stops": [
+              [
+                10,
+                "rgba(84, 84, 84, 0.3)"
+              ],
+              [
+                13,
+                "rgba(84, 84, 84, 1)"
+              ]
+            ]
+          },
           "line-width": {
             "stops": [
               [
@@ -245,7 +278,18 @@
           ]
         ],
         "paint": {
-          "line-color": "#AFAFAF",
+          "line-color": {
+            "stops": [
+              [
+                10,
+                "rgba(175, 175, 175, 0.3)"
+              ],
+              [
+                13,
+                "rgba(175, 175, 175, 1)"
+              ]
+            ]
+          },
           "line-width": {
             "stops": [
               [
@@ -281,7 +325,7 @@
          "label": "Mapped Street",
          "style": {
             "fill": "none",
-            "stroke": "#000"
+            "stroke": "rgba(50, 50, 50, 1)"
          }
       },
       {
@@ -289,7 +333,7 @@
            "label": "Record Street",
            "style": {
               "fill": "none",
-              "stroke": "#000",
+              "stroke": "rgba(50, 50, 50, 1)",
               "strokeWidth": "1",
               "strokeDasharray": "3, 1.5"
            }


### PR DESCRIPTION
This PR adds breaks to `citymap.json` so that the opacity of the streets fade in from zoom level 10 as to avoid the moiré pattern caused by the street grid and the screen's pixel grid. 

![image](https://user-images.githubusercontent.com/409279/40129652-d6c4f092-5902-11e8-9574-018336a66a14.png)

Closes #129. 

