### PR TITLE
Editable:false Print Config

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -454,9 +454,11 @@ export default class ApplicationController extends ParachuteController {
         pitch: map.getPitch(), // eslint-disable-line
       },
       logo: 'https://raw.githubusercontent.com/NYCPlanning/logo/master/dcp_logo_772.png',
-      title: 'NYC Street Map',
+      title: 'Street Map',
       content: 'This map was printed from NYC Street Map Application created by the NYC Department of City Planning. It is not an official record and all information displayed must be confirmed based on official records.',
+      contentEditable: false,
       source: 'NYC Street Map | https://streetmap.planning.nyc.gov',
+      sourceEditable: false,
     };
 
     if (visibleLegendConfigs.length > 0) printConfig.legendConfig = visibleLegendConfigs;


### PR DESCRIPTION
This PR adds booleans for the print config so that the content and source are not editable in the print service. Requires https://github.com/NYCPlanning/labs-mapboxgl-print-service/pull/11 be merged and deployed. Closes #159.
