### PR TITLE
change amendments layer style, change layer before defaults

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -61,7 +61,7 @@
                   line-cap='round'
                 )
               )
-              before='place_other'
+              before='boundary_country'
             }}
             {{source.layer layer=(hash
                 type='line'
@@ -79,7 +79,7 @@
                   line-cap='round'
                 )
               )
-              before='place_other'
+              before='boundary_country'
             }}
           {{/map.source}}
         {{/if}}
@@ -102,7 +102,7 @@
                 line-cap='round'
               )
             )
-            before='place_other'
+            before='boundary_country'
           }}
           {{source.layer layer=(hash
               type='line'
@@ -120,7 +120,7 @@
                 line-cap='round'
               )
             )
-            before='place_other'
+            before='boundary_country'
           }}
         {{/map.source}}
       {{/if}}
@@ -138,7 +138,7 @@
                 line-cap='round'
               )
             )
-            before='place_other'
+            before='boundary_country'
           }}
           {{source.layer layer=(hash
               type='line'
@@ -156,7 +156,7 @@
                 line-cap='round'
               )
             )
-            before='place_other'
+            before='boundary_country'
           }}
         {{/map.source}}
       {{/if}}
@@ -172,7 +172,7 @@
                 circle-stroke-color="#FFFFFF"
               )
             )
-            before='place_other'
+            before='boundary_country'
           }}
         {{/map.source}}
       {{/if}}

--- a/json/layer-groups/amendments.json
+++ b/json/layer-groups/amendments.json
@@ -3,7 +3,7 @@
   "title": "City Map Alterations",
   "titleTooltip": "An index of alterations to the City Map. Alteration Maps show changes made to the City Map and, when they are the most recent in an area, serve as an official record of the City Map in the area they depict.",
   "legendIcon": "polygon-stacked",
-  "legendColor": "rgba(60, 133, 210, 0.4)",
+  "legendColor": "rgba(174, 86, 31, 0.4)",
   "visible": true,
   "highlightable": false,
   "meta": {
@@ -12,13 +12,14 @@
   },
   "layers": [
     {
+      "before": "place_other",
       "style": {
         "id": "citymap-amendments-fill",
         "type": "fill",
         "source": "digital-citymap",
         "source-layer": "amendments",
         "paint": {
-          "fill-color": "rgba(60, 133, 210, 0.2)"
+          "fill-color": "rgba(174, 86, 31, 0.2)"
         },
         "layout": {}
       }
@@ -31,7 +32,7 @@
         "label": "City Map Alterations",
         "style": {
           "stroke": "none",
-          "fill": "rgba(60, 133, 210, 0.4)"
+          "fill": "rgba(174, 86, 31, 0.4)"
         }
       }
     ]

--- a/lib/labs-maps/addon/models/layer.js
+++ b/lib/labs-maps/addon/models/layer.js
@@ -36,7 +36,7 @@ export default class LayerModel extends Model {
     return this.get('style');
   }
 
-  @attr('string', { defaultValue: 'place_other' }) before
+  @attr('string', { defaultValue: 'boundary_country' }) before
 
   @attr('string') displayName;
 


### PR DESCRIPTION
This PR changes the color of amendments layer from blue to orange so that they contrast with the flood plain layer. 

![image](https://user-images.githubusercontent.com/409279/40250627-d88ea794-5aa4-11e8-8f23-d0fd8da755f4.png)

Closes #165.