### PR TITLE
adjust arterials symbology

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -249,10 +249,9 @@
       {{#lookup-layer-group for='arterials' as |layerGroup|}}
         {{#menu.menu-item
           title=layerGroup.model.title
-          legendColor=layerGroup.model.legendColor
-          legendIcon=layerGroup.model.legendIcon
           tooltip=layerGroup.model.titleTooltip
           active=arterials}}
+          {{labs-map-legend model=layerGroup.model.legendConfig}}
         {{/menu.menu-item}}
       {{/lookup-layer-group}}
 

--- a/json/layer-groups/arterials.json
+++ b/json/layer-groups/arterials.json
@@ -1,6 +1,6 @@
 {
   "id": "arterials",
-  "title": "Arterials",
+  "title": "Arterial Highways & Major Streets",
   "titleTooltip": "Designated rights-of-way shown on the Master Plan of Arterial Highways and Major Streets (not an exact copy).",
   "visible": false,
   "meta": {
@@ -61,11 +61,11 @@
     }
   ],
   "legendConfig": {
-    "label":"Arterials",
+    "label":"Arterial & Major Streets",
     "items":[
       {
         "type":"line",
-        "label":"Highway",
+        "label":"Arterial",
         "style":{
           "fill":"none",
           "stroke":"rgba(255, 210, 90, 1)"

--- a/json/layer-groups/arterials.json
+++ b/json/layer-groups/arterials.json
@@ -3,7 +3,7 @@
   "title": "Arterial Highways & Major Streets",
   "titleTooltip": "Designated rights-of-way shown on the Master Plan of Arterial Highways and Major Streets (not an exact copy).",
   "legendIcon": "line",
-  "legendColor": "rgba(245, 147, 80, 0.6)",
+  "legendColor": "rgba(253, 226, 147, 1)",
   "visible": false,
   "meta": {
     "description": "NYC Department of City Planning Technical Review Division",
@@ -17,7 +17,7 @@
         "source": "digital-citymap",
         "source-layer": "arterials",
         "paint": {
-          "line-color": "rgba(245, 147, 80, 0.4)",
+          "line-color": "rgba(253, 226, 147, 1)",
           "line-width": {
             "stops": [
               [
@@ -26,7 +26,19 @@
               ],
               [
                 14,
-                10
+                6
+              ],
+              [
+                16,
+                20
+              ],
+              [
+                18,
+                50
+              ],
+              [
+                19,
+                100
               ]
             ]
           }

--- a/json/layer-groups/arterials.json
+++ b/json/layer-groups/arterials.json
@@ -1,9 +1,7 @@
 {
   "id": "arterials",
-  "title": "Arterial Highways & Major Streets",
+  "title": "Arterials",
   "titleTooltip": "Designated rights-of-way shown on the Master Plan of Arterial Highways and Major Streets (not an exact copy).",
-  "legendIcon": "line",
-  "legendColor": "rgba(253, 226, 147, 1)",
   "visible": false,
   "meta": {
     "description": "NYC Department of City Planning Technical Review Division",
@@ -17,7 +15,20 @@
         "source": "digital-citymap",
         "source-layer": "arterials",
         "paint": {
-          "line-color": "rgba(253, 226, 147, 1)",
+          "line-color": {
+            "property": "route_type",
+            "type": "categorical",
+            "stops": [
+              [
+                "Arterial Highway",
+                "rgba(255, 210, 90, 1)"
+              ],
+              [
+                "Major Streets",
+                "rgba(250, 230, 180, 1)"
+              ]
+            ]
+          },
           "line-width": {
             "stops": [
               [
@@ -48,5 +59,26 @@
         }
       }
     }
-  ]
+  ],
+  "legendConfig": {
+    "label":"Arterials",
+    "items":[
+      {
+        "type":"line",
+        "label":"Highway",
+        "style":{
+          "fill":"none",
+          "stroke":"rgba(255, 210, 90, 1)"
+        }
+      },
+      {
+        "type":"line",
+        "label":"Major Street",
+        "style":{
+          "fill":"none",
+          "stroke":"rgba(250, 230, 180, 1)"
+        }
+      }
+    ]
+  }
 }

--- a/public/sources.json
+++ b/public/sources.json
@@ -9,7 +9,7 @@
       },
       {
         "id": "arterials",
-        "sql": "SELECT the_geom_webmercator FROM citymap_arterials_v0"
+        "sql": "SELECT the_geom_webmercator, route_type FROM citymap_arterials_v0"
       },
       {
         "id": "pierhead-lines",


### PR DESCRIPTION
This PR adjust the color and thickness of the Arterials layer group so that it stands out against the other layers, symbolizes the highways and major roads separately, and fills the average street width more appropriately at various zoom levels. 

![image](https://user-images.githubusercontent.com/409279/40327584-809f5a1e-5d11-11e8-8909-3eabfcd119df.png)
