### PR TITLE
add local law name change labels, add links to council resolutions in…

### DIFF
--- a/app/components/map-popup-content.js
+++ b/app/components/map-popup-content.js
@@ -74,6 +74,19 @@ export default class MapPopupContent extends Component {
     return cleanLots;
   }
 
+  @computed('features')
+  get streetNameChanges() {
+    const features = this.get('features');
+
+    if (features === null) return features;
+
+    // add a timestamp property to sort by
+    const streetNameChanges = features
+      .filter(d => d.properties.type === 'streetnamechange');
+
+    return streetNameChanges;
+  }
+
   @argument
   features = [];
 

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -277,7 +277,21 @@ export default class ApplicationController extends ParachuteController {
 
     carto.SQL(SQL, 'geojson')
       .then((FC) => {
-        this.set('popupFeatures', FC.features);
+        // sigh... queryRenderedFeatures() for street name changes and append the results to the Features returned from Carto
+        const map = this.get('map');
+        const layers = ['citymap-name-changes-circle', 'citymap-name-changes-line', 'citymap-name-changes-fill'];
+        const streetNameChanges = map.queryRenderedFeatures(
+          e.point,
+          { layers },
+        );
+
+        // append a type property for use in rendering the popup
+        streetNameChanges.forEach((feature) => {
+          feature.properties.type = 'streetnamechange'; // eslint-disable-line
+          return feature;
+        });
+
+        this.set('popupFeatures', [...FC.features, ...streetNameChanges]);
       });
   }
 
@@ -386,7 +400,6 @@ export default class ApplicationController extends ParachuteController {
   handleMapMouseDrag() {
     const map = this.get('map');
     map.getCanvas().style.cssText += 'cursor:-webkit-grabbing; cursor:-moz-grabbing; cursor:grabbing;';
-    console.log(map.getCanvas().style.cssText);
   }
 
   @action

--- a/app/templates/components/map-popup-content.hbs
+++ b/app/templates/components/map-popup-content.hbs
@@ -37,7 +37,7 @@
     <h4 class="popup-header">Local Law Names</h4>
     <ul class="popup-list no-bullet no-margin">
       {{#each streetNameChanges as |nameChange|}}
-        <a href="https://laws.council.nyc.gov/legislation/int-{{nameChange.properties.intronumbe}}-{{nameChange.properties.intro_year}}/" target="_blank" rel="noopener">{{nameChange.properties.honoraryna}} {{fa-icon 'external-link'}}</a><br>
+        <a href="https://laws.council.nyc.gov/legislation/int-{{nameChange.properties.intronumbe}}-{{nameChange.properties.intro_year}}/" target="_blank" rel="noopener"> {{fa-icon 'external-link'}}{{nameChange.properties.honoraryna}} - {{nameChange.properties.ll_effecti}}</a><br>
       {{/each}}
     </ul>
   {{/if}}

--- a/app/templates/components/map-popup-content.hbs
+++ b/app/templates/components/map-popup-content.hbs
@@ -32,5 +32,14 @@
     </ul>
   {{/if}}
 
+  {{#if streetNameChanges}}
+    <hr class="small-margin">
+    <h4 class="popup-header">Local Law Names</h4>
+    <ul class="popup-list no-bullet no-margin">
+      {{#each streetNameChanges as |nameChange|}}
+        <a href="https://laws.council.nyc.gov/legislation/int-{{nameChange.properties.intronumbe}}-{{nameChange.properties.intro_year}}/" target="_blank" rel="noopener">{{nameChange.properties.honoraryna}} {{fa-icon 'external-link'}}</a><br>
+      {{/each}}
+    </ul>
+  {{/if}}
   {{yield}}
 </div>

--- a/json/layer-groups/name-changes.json
+++ b/json/layer-groups/name-changes.json
@@ -1,29 +1,29 @@
 {
-  "id": "name-changes",
-  "title": "Local Law Names",
-  "titleTooltip": "Local Law name changes to thoroughfares and public places from 2002 to present",
-  "legendIcon": "",
-  "legendColor": "",
-  "visible": false,
-  "meta": {
-    "description": "NYC Department of City Planning Technical Review Division",
-    "updated_at": "6 April 2018"
+  "id":"name-changes",
+  "title":"Local Law Names",
+  "titleTooltip":"Local Law name changes to thoroughfares and public places from 2002 to present",
+  "legendIcon":"",
+  "legendColor":"",
+  "visible":false,
+  "meta":{
+    "description":"NYC Department of City Planning Technical Review Division",
+    "updated_at":"6 April 2018"
   },
-  "layers": [
+  "layers":[
     {
-      "style": {
-        "id": "citymap-name-changes-circle",
-        "type": "circle",
-        "source": "digital-citymap",
-        "source-layer": "name-changes-points",
-        "layout": {
-          "visibility": "visible"
+      "style":{
+        "id":"citymap-name-changes-circle",
+        "type":"circle",
+        "source":"digital-citymap",
+        "source-layer":"name-changes-points",
+        "layout":{
+          "visibility":"visible"
         },
-        "paint": {
-          "circle-stroke-color": "rgba(49, 49, 49, 1)",
-          "circle-color": "rgba(228, 72, 192, 1)",
-          "circle-stroke-width": {
-            "stops": [
+        "paint":{
+          "circle-stroke-color":"rgba(49, 49, 49, 1)",
+          "circle-color":"rgba(228, 72, 192, 1)",
+          "circle-stroke-width":{
+            "stops":[
               [
                 10,
                 0.5
@@ -34,8 +34,8 @@
               ]
             ]
           },
-          "circle-radius": {
-            "stops": [
+          "circle-radius":{
+            "stops":[
               [
                 10,
                 1
@@ -50,15 +50,15 @@
       }
     },
     {
-      "style": {
-        "id": "citymap-name-changes-line",
-        "type": "line",
-        "source": "digital-citymap",
-        "source-layer": "name-changes-lines",
-        "paint": {
-          "line-color": "rgba(228, 72, 192, 1)",
-          "line-width": {
-            "stops": [
+      "style":{
+        "id":"citymap-name-changes-line",
+        "type":"line",
+        "source":"digital-citymap",
+        "source-layer":"name-changes-lines",
+        "paint":{
+          "line-color":"rgba(228, 72, 192, 1)",
+          "line-width":{
+            "stops":[
               [
                 10,
                 1
@@ -69,19 +69,158 @@
               ]
             ]
           },
-          "line-opacity": 0.5
+          "line-opacity":0.5
+        }
+      }
+    },
+    {
+      "style":{
+        "id":"citymap-name-changes-fill",
+        "type":"fill",
+        "source":"digital-citymap",
+        "source-layer":"name-changes-areas",
+        "paint":{
+          "fill-color":"rgba(228, 72, 192, 1)",
+          "fill-opacity":0.5
+        }
+      }
+    },
+    {
+      "style":{
+        "id":"citymap-name-changes-circle-label",
+        "type":"symbol",
+        "source":"digital-citymap",
+        "source-layer":"name-changes-points",
+        "filter":[
+          "all"
+        ],
+        "layout":{
+          "text-field":"{honoraryna}",
+          "text-font":[
+            "Open Sans Regular",
+            "Arial Unicode MS Regular"
+          ],
+          "text-size":11,
+          "text-justify":"left",
+          "text-anchor":"left",
+          "text-offset":[
+            1.5,
+            0
+          ]
+        },
+        "paint":{
+          "text-opacity":{
+            "stops":[
+              [
+                14.5,
+                0
+              ],
+              [
+                15.5,
+                1
+              ]
+            ]
+          },
+          "text-color":"rgba(0, 0, 0, 1)",
+          "text-halo-color":"rgba(152, 152, 152, 0)"
         }
       }
     },
     {
       "style": {
-        "id": "citymap-name-changes-fill",
-        "type": "fill",
+        "id": "citymap-name-changes-lines-label",
+        "type": "symbol",
+        "source": "digital-citymap",
+        "source-layer": "name-changes-lines",
+        "filter": [
+          "all"
+        ],
+        "layout": {
+          "text-field": "{honoraryna}",
+          "text-font": [
+            "Open Sans Regular",
+            "Arial Unicode MS Regular"
+          ],
+          "text-size": 11,
+          "text-justify": "left",
+          "text-anchor": "center",
+          "text-offset": [
+            0,
+            2
+          ],
+          "symbol-placement": "line",
+          "symbol-avoid-edges": false,
+          "text-keep-upright": true,
+          "text-optional": false,
+          "icon-allow-overlap": false,
+          "symbol-spacing": 250,
+          "visibility": "visible",
+          "text-transform": "none"
+        },
+        "paint": {
+          "text-opacity": {
+            "stops": [
+              [
+                14.5,
+                0
+              ],
+              [
+                15.5,
+                1
+              ]
+            ]
+          },
+          "text-color": "rgba(0, 0, 0, 1)",
+          "text-halo-color": "rgba(152, 152, 152, 0)"
+        }
+      }
+    },
+    {
+      "style": {
+        "id": "citymap-name-changes-areas-label",
+        "type": "symbol",
         "source": "digital-citymap",
         "source-layer": "name-changes-areas",
+        "filter": [
+          "all"
+        ],
+        "layout": {
+          "text-field": "{honoraryna}",
+          "text-font": [
+            "Open Sans Regular",
+            "Arial Unicode MS Regular"
+          ],
+          "text-size": 11,
+          "text-justify": "center",
+          "text-anchor": "center",
+          "text-offset": [
+            0,
+            0
+          ],
+          "symbol-placement": "point",
+          "symbol-avoid-edges": false,
+          "text-keep-upright": true,
+          "text-optional": false,
+          "icon-allow-overlap": false,
+          "symbol-spacing": 250,
+          "text-transform": "none",
+          "visibility": "visible"
+        },
         "paint": {
-          "fill-color": "rgba(228, 72, 192, 1)",
-          "fill-opacity": 0.5
+          "text-opacity": {
+            "stops": [
+              [
+                14.5,
+                0
+              ],
+              [
+                15.5,
+                1
+              ]
+            ]
+          },
+          "text-color": "rgba(0, 0, 0, 1)",
+          "text-halo-color": "rgba(152, 152, 152, 0)"
         }
       }
     }

--- a/public/sources.json
+++ b/public/sources.json
@@ -29,15 +29,15 @@
       },
       {
         "id": "name-changes-points",
-        "sql": "SELECT the_geom_webmercator FROM citymap_streetnamechanges_points_v0"
+        "sql": "SELECT the_geom_webmercator, intronumbe, intro_year, CASE WHEN honoraryna = 'none' THEN officialna ELSE honoraryna END FROM citymap_streetnamechanges_points_v0"
       },
       {
         "id": "name-changes-lines",
-        "sql": "SELECT the_geom_webmercator FROM citymap_streetnamechanges_streets_v0"
+        "sql": "SELECT the_geom_webmercator, intronumbe, intro_year, CASE WHEN honoraryna = 'none' THEN officialna ELSE honoraryna END FROM citymap_streetnamechanges_streets_v0"
       },
       {
         "id": "name-changes-areas",
-        "sql": "SELECT the_geom_webmercator FROM citymap_streetnamechanges_areas_v0"
+        "sql": "SELECT the_geom_webmercator, intronumbe, intro_year, CASE WHEN honoraryna = 'none' THEN officialna ELSE honoraryna END FROM citymap_streetnamechanges_areas_v0"
       }
     ]
   },

--- a/public/sources.json
+++ b/public/sources.json
@@ -29,15 +29,15 @@
       },
       {
         "id": "name-changes-points",
-        "sql": "SELECT the_geom_webmercator, intronumbe, intro_year, CASE WHEN honoraryna = 'none' THEN officialna ELSE honoraryna END FROM citymap_streetnamechanges_points_v0"
+        "sql": "SELECT the_geom_webmercator, intronumbe, intro_year, ll_effecti, CASE WHEN honoraryna = 'none' THEN officialna ELSE honoraryna END FROM citymap_streetnamechanges_points_v0"
       },
       {
         "id": "name-changes-lines",
-        "sql": "SELECT the_geom_webmercator, intronumbe, intro_year, CASE WHEN honoraryna = 'none' THEN officialna ELSE honoraryna END FROM citymap_streetnamechanges_streets_v0"
+        "sql": "SELECT the_geom_webmercator, intronumbe, intro_year, ll_effecti, CASE WHEN honoraryna = 'none' THEN officialna ELSE honoraryna END FROM citymap_streetnamechanges_streets_v0"
       },
       {
         "id": "name-changes-areas",
-        "sql": "SELECT the_geom_webmercator, intronumbe, intro_year, CASE WHEN honoraryna = 'none' THEN officialna ELSE honoraryna END FROM citymap_streetnamechanges_areas_v0"
+        "sql": "SELECT the_geom_webmercator, intronumbe, intro_year, ll_effecti, CASE WHEN honoraryna = 'none' THEN officialna ELSE honoraryna END FROM citymap_streetnamechanges_areas_v0"
       }
     ]
   },


### PR DESCRIPTION
This PR:

- adds labels to all three local law name layers (point, line, area), visible after zoom 14.5.
- adds local law names to popup, including a link to the relevant council resolution
- tooltips were deemed overkill at this point, open to suggestions if the current implementation isn't informative enough.

Closes #122