### PR TITLE
142 stair streets

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -86,6 +86,10 @@ export const LayerVisibilityParams = new QueryParams({
     defaultValue: false,
     refresh: true,
   },
+  'paper-streets': {
+    defaultValue: false,
+    refresh: true,
+  },
   aerials: {
     defaultValue: false,
     refresh: true,

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -78,6 +78,10 @@ export const LayerVisibilityParams = new QueryParams({
     defaultValue: false,
     refresh: true,
   },
+  'stair-streets': {
+    defaultValue: false,
+    refresh: true,
+  },
   aerials: {
     defaultValue: false,
     refresh: true,

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -288,7 +288,19 @@
         {{#menu.menu-item
           title=layerGroup.model.title
           tooltip=layerGroup.model.titleTooltip
+          legendColor=layerGroup.model.legendColor
+          legendIcon=layerGroup.model.legendIcon
           active=stair-streets}}
+        {{/menu.menu-item}}
+      {{/lookup-layer-group}}
+
+      {{#lookup-layer-group for='paper-streets' as |layerGroup|}}
+        {{#menu.menu-item
+          title=layerGroup.model.title
+          tooltip=layerGroup.model.titleTooltip
+          legendColor=layerGroup.model.legendColor
+          legendIcon=layerGroup.model.legendIcon
+          active=paper-streets}}
         {{/menu.menu-item}}
       {{/lookup-layer-group}}
     {{/accordion-menu}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -274,6 +274,14 @@
           </ul>
         {{/menu.menu-item}}
       {{/lookup-layer-group}}
+
+      {{#lookup-layer-group for='stair-streets' as |layerGroup|}}
+        {{#menu.menu-item
+          title=layerGroup.model.title
+          tooltip=layerGroup.model.titleTooltip
+          active=stair-streets}}
+        {{/menu.menu-item}}
+      {{/lookup-layer-group}}
     {{/accordion-menu}}
 
     {{!-- Supporting Layers --}}

--- a/app/templates/components/legend-icon.hbs
+++ b/app/templates/components/legend-icon.hbs
@@ -36,4 +36,10 @@
   </span>
 {{/if}}
 
+{{#if (eq legendIcon 'four-vertical-lines')}}
+  <span class="point" style={{legendColorStyle}}>
+    {{fa-icon 'align-justify' style="transform:rotate(90deg);"}}
+  </span>
+{{/if}}
+
 {{!-- {{yield}} --}}

--- a/json/layer-groups/citymap.json
+++ b/json/layer-groups/citymap.json
@@ -278,6 +278,7 @@
       {
         "type":"line",
         "label":"Mapped Street",
+        "tooltip":"A street that has been established on an adopted alteration map or section map and filed with the appropriate agencies",
         "style":{
           "fill":"none",
           "stroke": "rgba(50, 50, 50, 1)"
@@ -286,6 +287,7 @@
       {
         "type":"line",
         "label":"Street Treatment",
+        "tooltip":"Lines on the City Map that reflect curb lines, approach ramps and other physical elements for illustrative purposes only - may be changed without public review (ULURP)",
         "style":{
           "fill":"none",
           "stroke":"rgba(84, 84, 84, 1)",
@@ -295,6 +297,7 @@
       {
         "type":"line",
         "label":"Unmapped Street",
+        "tooltip":"A street that may or may not be a public way, that is either not officially mapped but is documented in some other legal record or that has been built but does not appear on the City Map",
         "style":{
           "fill":"none",
           "stroke":"rgba(50, 50, 50, 0.4)",

--- a/json/layer-groups/paper-streets.json
+++ b/json/layer-groups/paper-streets.json
@@ -1,14 +1,15 @@
 {
-  "id":"stair-streets",
-  "title":"Stair Streets",
-  "legendIcon": "four-vertical-lines",
-  "legendColor": "rgba(30, 164, 39, 1)",
-  "titleTooltip": "Street segments with steps or stairs to accommodate foot traffic.",
+  "id":"paper-streets",
+  "title":"Paper Streets",
+  "legendIcon": "polygon",
+  "legendColor": "rgba(30, 164, 39, 0.8)",
+  "titleTooltip": "Streets that are officially mapped but are not built and only appear on paper maps",
   "visible":false,
   "layers":[
     {
       "style":{
-        "id": "stair-streets-line",
+        "id": "paper-streets-line",
+        "before":"boundary_country",
         "type": "line",
         "source": "digital-citymap",
         "source-layer": "street-centerlines",
@@ -16,12 +17,12 @@
           "all",
           [
             "==",
-            "roadway_ty",
-            "Step_Stair_ST"
+            "feature_st",
+            "Paper_St"
           ]
         ],
         "paint": {
-          "line-color": "rgba(30, 164, 39, 1)",
+          "line-color": "rgba(30, 164, 39, 0.8)",
           "line-width": {
             "stops": [
               [
@@ -45,11 +46,7 @@
                 100
               ]
             ]
-          },
-          "line-dasharray": [
-            0.2,
-            0.3
-          ]
+          }
         }
       }
     }

--- a/json/layer-groups/stair-streets.json
+++ b/json/layer-groups/stair-streets.json
@@ -1,0 +1,48 @@
+{
+  "id":"stair-streets",
+  "title":"Stair Streets",
+  "legendIcon":"",
+  "legendColor":"",
+  "visible":false,
+  "layers":[
+    {
+      "style":{
+        "id": "stair-streets-line",
+        "type": "line",
+        "source": "digital-citymap",
+        "source-layer": "street-centerlines",
+        "filter": [
+          "all",
+          [
+            "==",
+            "roadway_ty",
+            "Step_Stair_ST"
+          ]
+        ],
+        "paint": {
+          "line-color": "rgba(30, 164, 39, 1)",
+          "line-width": {
+            "stops": [
+              [
+                10,
+                0.2
+              ],
+              [
+                13,
+                2
+              ],
+              [
+                15,
+                6
+              ]
+            ]
+          },
+          "line-dasharray": [
+            0.2,
+            0.3
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-fetch": "3.4.5",
     "ember-font-awesome": "^4.0.0-rc.2",
-    "ember-labs-maps": "nycplanning/ember-labs-maps#v0.1.1",
+    "ember-labs-maps": "nycplanning/ember-labs-maps",
     "ember-load-initializers": "^1.0.0",
     "ember-macro-helpers": "1.0.0",
     "ember-mapbox-gl": "0.9.1",

--- a/public/sources.json
+++ b/public/sources.json
@@ -21,7 +21,7 @@
       },
       {
         "id": "street-centerlines",
-        "sql": "SELECT the_geom_webmercator, official_s AS streetname, COALESCE('   (' || streetwidt || ' ft)') AS streetwidth, roadway_ty FROM citymap_streetcenterlines_v0"
+        "sql": "SELECT the_geom_webmercator, official_s AS streetname, COALESCE('   (' || streetwidt || ' ft)') AS streetwidth, roadway_ty, feature_st FROM citymap_streetcenterlines_v0"
       },
       {
         "id": "citymap",

--- a/public/sources.json
+++ b/public/sources.json
@@ -21,7 +21,7 @@
       },
       {
         "id": "street-centerlines",
-        "sql": "SELECT the_geom_webmercator, official_s AS streetname, COALESCE('   (' || streetwidt || ' ft)') AS streetwidth FROM citymap_streetcenterlines_v0"
+        "sql": "SELECT the_geom_webmercator, official_s AS streetname, COALESCE('   (' || streetwidt || ' ft)') AS streetwidth, roadway_ty FROM citymap_streetcenterlines_v0"
       },
       {
         "id": "citymap",

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,6 +91,19 @@
     ember-source-channel-url "^1.0.1"
     ember-try "^0.2.23"
 
+"@ember-decorators/argument@0.8.15":
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/argument/-/argument-0.8.15.tgz#9b0be4b8ca362a9fb79af0bad5249575a2cbd6fa"
+  dependencies:
+    babel-plugin-filter-imports "^1.1.1"
+    broccoli-funnel "^2.0.1"
+    ember-cli-babel "^6.3.0"
+    ember-cli-version-checker "^2.0.0"
+    ember-compatibility-helpers "^1.0.0-beta.2"
+    ember-get-config "^0.2.3"
+    ember-source-channel-url "^1.0.1"
+    ember-try "^0.2.23"
+
 "@ember-decorators/argument@ember-decorators/argument":
   version "0.8.13"
   resolved "https://codeload.github.com/ember-decorators/argument/tar.gz/2b1dc14362214e906591f6ed0cf66db2676aa4d0"
@@ -129,6 +142,13 @@
     "@ember-decorators/utils" "^2.0.0"
     ember-cli-babel "^6.6.0"
 
+"@ember-decorators/component@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/component/-/component-2.1.0.tgz#846ad4197a06c9814d02654e947c023d35107cee"
+  dependencies:
+    "@ember-decorators/utils" "^2.1.0"
+    ember-cli-babel "^6.6.0"
+
 "@ember-decorators/controller@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@ember-decorators/controller/-/controller-2.0.0.tgz#4bd48ab4ff59ec113f1efab9c725eaaf0a6162c0"
@@ -136,11 +156,25 @@
     "@ember-decorators/utils" "^2.0.0"
     ember-cli-babel "^6.6.0"
 
+"@ember-decorators/controller@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/controller/-/controller-2.1.0.tgz#57a7be3d4eaa18e5021096d404417b1b943e7124"
+  dependencies:
+    "@ember-decorators/utils" "^2.1.0"
+    ember-cli-babel "^6.6.0"
+
 "@ember-decorators/data@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@ember-decorators/data/-/data-2.0.0.tgz#1a9b2160bf6c57ddcb649299e673680ea0ad3df8"
   dependencies:
     "@ember-decorators/utils" "^2.0.0"
+    ember-cli-babel "^6.6.0"
+
+"@ember-decorators/data@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/data/-/data-2.1.0.tgz#df29cc4bb21b7f246a02f810e2c7b56bd6f25294"
+  dependencies:
+    "@ember-decorators/utils" "^2.1.0"
     ember-cli-babel "^6.6.0"
 
 "@ember-decorators/object@^2.0.0":
@@ -151,11 +185,26 @@
     ember-cli-babel "^6.6.0"
     ember-compatibility-helpers "^0.1.3"
 
+"@ember-decorators/object@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/object/-/object-2.1.0.tgz#725c790c030299a4bc8c15f21048c3c0abc1499c"
+  dependencies:
+    "@ember-decorators/utils" "^2.1.0"
+    ember-cli-babel "^6.6.0"
+    ember-compatibility-helpers "^1.0.0"
+
 "@ember-decorators/service@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@ember-decorators/service/-/service-2.0.0.tgz#2a96eb099544d1552af13e1416ab1e2dc0c95110"
   dependencies:
     "@ember-decorators/utils" "^2.0.0"
+    ember-cli-babel "^6.6.0"
+
+"@ember-decorators/service@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/service/-/service-2.1.0.tgz#c6bbfd34fbb9fb19317ab2be351d8577701e5315"
+  dependencies:
+    "@ember-decorators/utils" "^2.1.0"
     ember-cli-babel "^6.6.0"
 
 "@ember-decorators/utils@^2.0.0":
@@ -164,6 +213,13 @@
   dependencies:
     ember-cli-babel "^6.6.0"
     ember-compatibility-helpers "1.0.0-beta.1"
+
+"@ember-decorators/utils@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/utils/-/utils-2.1.0.tgz#cd354ff59ce0d5faa74880c15db0f72fefe6dc70"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+    ember-compatibility-helpers "^1.0.0"
 
 "@ember/test-helpers@^0.7.18":
   version "0.7.20"
@@ -328,6 +384,10 @@ JSONStream@^1.0.3:
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+
+abortcontroller-polyfill@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.1.9.tgz#9fefe359fda2e9e0932dc85e6106453ac393b2da"
 
 accepts@~1.3.4, accepts@~1.3.5:
   version "1.3.5"
@@ -2281,6 +2341,13 @@ cartobox-promises-utility@nycplanning/cartobox-promises-utility:
   dependencies:
     ember-cli-babel "^6.6.0"
 
+cartobox-promises-utility@nycplanning/cartobox-promises-utility#v1.0.1:
+  version "0.0.0"
+  resolved "https://codeload.github.com/nycplanning/cartobox-promises-utility/tar.gz/4485296d07bea2dba49bb8ff6292e9cacbf584a4"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+    ember-fetch "4.0.1"
+
 caseless@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
@@ -3478,6 +3545,13 @@ ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0:
     resolve "^1.3.3"
     semver "^5.3.0"
 
+ember-cli-version-checker@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.1.2.tgz#305ce102390c66e4e0f1432dea9dc5c7c19fed98"
+  dependencies:
+    resolve "^1.3.3"
+    semver "^5.3.0"
+
 ember-cli@~3.1.0-beta.1:
   version "3.1.0-beta.1"
   resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-3.1.0-beta.1.tgz#a0edc2fcb0d68e3d09128200cf08c76fb6a76ebf"
@@ -3582,6 +3656,14 @@ ember-compatibility-helpers@^0.1.3:
     ember-cli-version-checker "^2.0.0"
     semver "^5.4.1"
 
+ember-compatibility-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.0.0.tgz#616b22d2e14b4c6a1f4441e5390a49abf52b3c68"
+  dependencies:
+    babel-plugin-debug-macros "^0.1.11"
+    ember-cli-version-checker "^2.1.1"
+    semver "^5.4.1"
+
 ember-compatibility-helpers@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.0.0-beta.2.tgz#00cb134af45f9562fa47a23f4da81a63aad41943"
@@ -3659,6 +3741,18 @@ ember-decorators@2.0.0:
     ember-cli-babel "^6.0.0"
     semver "^5.5.0"
 
+ember-decorators@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ember-decorators/-/ember-decorators-2.1.0.tgz#4910835da3517c633532c8d6fcfcf026e13701c0"
+  dependencies:
+    "@ember-decorators/component" "^2.1.0"
+    "@ember-decorators/controller" "^2.1.0"
+    "@ember-decorators/data" "^2.1.0"
+    "@ember-decorators/object" "^2.1.0"
+    "@ember-decorators/service" "^2.1.0"
+    ember-cli-babel "^6.0.0"
+    semver "^5.5.0"
+
 ember-export-application-global@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.0.tgz#8d6d7619ac8a1a3f8c43003549eb21ebed685bd2"
@@ -3681,6 +3775,19 @@ ember-fetch@3.4.5:
     ember-cli-babel "^6.8.2"
     node-fetch "^2.0.0-alpha.9"
     whatwg-fetch "^2.0.3"
+
+ember-fetch@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/ember-fetch/-/ember-fetch-4.0.1.tgz#0d43517c5e26de7ebd0777c983d675e79ecb40ad"
+  dependencies:
+    abortcontroller-polyfill "^1.1.9"
+    broccoli-concat "^3.2.2"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-stew "^1.4.2"
+    broccoli-templater "^1.0.0"
+    ember-cli-babel "^6.8.2"
+    node-fetch "^2.0.0-alpha.9"
+    yetch "^0.0.1"
 
 ember-font-awesome@^4.0.0-rc.2:
   version "4.0.0-rc.2"
@@ -3719,18 +3826,22 @@ ember-inflector@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0"
 
-ember-labs-maps@nycplanning/ember-labs-maps#v0.1.1:
+ember-labs-maps@nycplanning/ember-labs-maps:
   version "0.0.0"
-  resolved "https://codeload.github.com/nycplanning/ember-labs-maps/tar.gz/f17ce5c00b5cfd45bde1b166844ec38f885cf447"
+  resolved "https://codeload.github.com/nycplanning/ember-labs-maps/tar.gz/14138fd89f6d64ccee248884373dbccdab5b7f67"
   dependencies:
-    "@ember-decorators/argument" "0.8.13"
+    "@ember-decorators/argument" "0.8.15"
     "@ember-decorators/babel-transforms" "^2.0.0"
+    cartobox-promises-utility nycplanning/cartobox-promises-utility#v1.0.1
     ember-cli-babel "^6.6.0"
     ember-cli-htmlbars "^2.0.1"
     ember-cli-htmlbars-inline-precompile "^1.0.0"
-    ember-decorators "2.0.0"
+    ember-decorators "2.1.0"
+    ember-font-awesome "^4.0.0-rc.2"
     ember-mapbox-gl "0.10.0"
+    ember-tooltips "^3.0.0-beta.2"
     ember-truth-helpers "2.0.0"
+    pretender "2.0.0"
 
 ember-load-initializers@^1.0.0:
   version "1.0.0"
@@ -4545,6 +4656,10 @@ extglob@^2.0.4:
 extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+
+fake-xml-http-request@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fake-xml-http-request/-/fake-xml-http-request-2.0.0.tgz#41a92f0ca539477700cb1dafd2df251d55dac8ff"
 
 falafel@^2.1.0:
   version "2.1.0"
@@ -7565,6 +7680,13 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+pretender@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pretender/-/pretender-2.0.0.tgz#5adae189f1d5b25f86113f9225df25bed54f4072"
+  dependencies:
+    fake-xml-http-request "^2.0.0"
+    route-recognizer "^0.3.3"
+
 printf@^0.2.3:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/printf/-/printf-0.2.5.tgz#c438ca2ca33e3927671db4ab69c0e52f936a4f0f"
@@ -8118,6 +8240,10 @@ rollup@^0.41.4:
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.41.6.tgz#e0d05497877a398c104d816d2733a718a7a94e2a"
   dependencies:
     source-map-support "^0.4.0"
+
+route-recognizer@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.3.3.tgz#1d365e27fa6995e091675f7dc940a8c00353bd29"
 
 rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.5.0:
   version "3.6.2"
@@ -9595,3 +9721,7 @@ yargs@~3.10.0:
 yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
+
+yetch@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/yetch/-/yetch-0.0.1.tgz#76f1729b2c2c667e23c3c2da90472a4897eca004"


### PR DESCRIPTION
This PR adds 2 new layergroups for stair-streets and paper-streets.

It also adds a `tooltip` property to the `legendConfig`, allowing for dynamic tooltips on legend items.  (This required a bugfix in `ember-labs-maps` which contained a hard-coded tooltip https://github.com/NYCPlanning/ember-labs-maps/commit/ec802624f8b4ca00b9750a3ea3b45e80b8ebe060)

Closes #142 
Closes #136