### PR TITLE
Style Paper/Stair Streets

### DIFF
--- a/json/layer-groups/paper-streets.json
+++ b/json/layer-groups/paper-streets.json
@@ -2,7 +2,7 @@
   "id":"paper-streets",
   "title":"Paper Streets",
   "legendIcon": "polygon",
-  "legendColor": "rgba(30, 164, 39, 0.8)",
+  "legendColor": "rgba(80, 80, 210, 0.8)",
   "titleTooltip": "Streets that are officially mapped but are not built and only appear on paper maps",
   "visible":false,
   "layers":[
@@ -22,7 +22,7 @@
           ]
         ],
         "paint": {
-          "line-color": "rgba(30, 164, 39, 0.8)",
+          "line-color": "rgba(80, 80, 210, 0.8)",
           "line-width": {
             "stops": [
               [
@@ -47,6 +47,43 @@
               ]
             ]
           }
+        }
+      }
+    },
+    {
+      "style":{
+        "id": "paper-streets-line-halo",
+        "type": "line",
+        "source": "digital-citymap",
+        "source-layer": "street-centerlines",
+        "filter": [
+          "all",
+          [
+            "==",
+            "feature_st",
+            "Paper_St"
+          ]
+        ],
+        "paint": {
+          "line-color": "rgba(80, 80, 210, 0.4)",
+          "line-width": {
+            "stops": [
+              [
+                13,
+                4
+              ],
+              [
+                14,
+                0
+              ]
+            ]
+          },
+          "line-translate-anchor": "map",
+          "line-gap-width": 2
+        },
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round"
         }
       }
     }

--- a/json/layer-groups/stair-streets.json
+++ b/json/layer-groups/stair-streets.json
@@ -2,7 +2,7 @@
   "id":"stair-streets",
   "title":"Stair Streets",
   "legendIcon": "four-vertical-lines",
-  "legendColor": "rgba(30, 164, 39, 1)",
+  "legendColor": "rgba(100, 170, 40, 0.8)",
   "titleTooltip": "Street segments with steps or stairs to accommodate foot traffic.",
   "visible":false,
   "layers":[
@@ -21,7 +21,7 @@
           ]
         ],
         "paint": {
-          "line-color": "rgba(30, 164, 39, 1)",
+          "line-color": "rgba(100, 170, 40, 0.8)",
           "line-width": {
             "stops": [
               [
@@ -46,10 +46,60 @@
               ]
             ]
           },
-          "line-dasharray": [
-            0.2,
-            0.3
+          "line-dasharray": {
+            "stops": [
+              [
+                13,
+                [
+                  1
+                ]
+              ],
+              [
+                14,
+                [
+                  0.2,
+                  0.2
+                ]
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+      "style":{
+        "id": "stair-streets-line-halo",
+        "type": "line",
+        "source": "digital-citymap",
+        "source-layer": "street-centerlines",
+        "filter": [
+          "all",
+          [
+            "==",
+            "roadway_ty",
+            "Step_Stair_ST"
           ]
+        ],
+        "paint": {
+          "line-color": "rgba(100, 170, 40, 0.5)",
+          "line-width": {
+            "stops": [
+              [
+                13,
+                4
+              ],
+              [
+                14,
+                0
+              ]
+            ]
+          },
+          "line-translate-anchor": "map",
+          "line-gap-width": 2
+        },
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round"
         }
       }
     }


### PR DESCRIPTION
This PR updates the style of Paper Streets and Stair Streets, adding a halo at low zoom levels so that they're noticeable when zoomed out. 

Closes #190.
Closes #185. 

![image](https://user-images.githubusercontent.com/409279/40857482-4ada7148-65a9-11e8-93c1-d08cd3d19255.png)

![image](https://user-images.githubusercontent.com/409279/40857521-69a0a070-65a9-11e8-982c-b6e8cac3ef44.png)
