### PR TITLE
Three-column Aerials list

### DIFF
--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -44,7 +44,7 @@ h6,
 //
 // Buttons
 // --------------------------------------------------
-button {
+button, label {
   cursor: pointer;
 }
 
@@ -269,7 +269,7 @@ hr.small-margin {
 
 
 //
-// Ember Tooltip
+// Images, Figures
 // --------------------------------------------------
 figure {
   margin-bottom: $global-margin;
@@ -295,5 +295,18 @@ figure {
     figcaption {
       color: $white;
     }
+  }
+}
+
+
+//
+// Multi-column lists
+// --------------------------------------------------
+.list-float-3 {
+  @include clearfix;
+
+  li {
+    float: left;
+    width: 33.33%;
   }
 }

--- a/app/styles/modules/_m-layer-menu.scss
+++ b/app/styles/modules/_m-layer-menu.scss
@@ -101,3 +101,15 @@
     border-style: dotted;
   }
 }
+
+.layer-menu-item--group-checkboxes {
+  margin: 0;
+
+  li {
+    padding: 0 0.375rem;
+
+    &:hover {
+      background-color: rgba(107,113,123,.06);
+    }
+  }
+}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -383,7 +383,7 @@
           title=layerGroup.model.title
           tooltip=layerGroup.model.titleTooltip
           active=aerials}}
-          <ul class="layer-menu-item--group-checkboxes list-float-3">
+          <ul class="layer-menu-item--group-checkboxes no-bullet list-float-3">
             {{#each layerGroup.model.layers as |layer|}}
               <li onclick={{action (mut selected-aerial) layer.id}} role='button'>
                 <label {{!template-lint-disable "nested-interactive"}}>


### PR DESCRIPTION
This PR styles the Aerials in 3 columns (as they are in ZoLa).

Also adds a hover styles to the radio buttons.

![image](https://user-images.githubusercontent.com/409279/40858251-ba954740-65ab-11e8-94a0-761ca7a3be9c.png)
