### PR TITLE
add component for boro office contact callout

### DIFF
--- a/app/components/boro-office-contact-callout.js
+++ b/app/components/boro-office-contact-callout.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -196,3 +196,12 @@ body {
     box-shadow: -4px 0 0 rgba(0,0,0,0.1);
   }
 }
+
+.grid-padding-small {
+  margin-right: -0.5rem;
+  margin-left: -0.5rem;
+
+  > .cell {
+    padding: 0.5rem;
+  }
+}

--- a/app/templates/components/boro-office-contact-callout.hbs
+++ b/app/templates/components/boro-office-contact-callout.hbs
@@ -1,0 +1,16 @@
+<div class="callout secondary">
+  <div class="grid-x grid-padding-small">
+    <p class="cell medium-auto">To confirm what you see in NYC Street Map with official City Map records, please contact the relevant Borough President’s Topographic Office:</p>
+    <div class="cell medium-auto">
+      <ul style="margin-bottom:0;">
+        <li>Bronx – <a target="_blank" rel="noopener" href="http://bronxboropres.nyc.gov/topography/"><strong>website</strong> {{fa-icon 'external-link' }}</a></li>
+        <li>Brooklyn – <a target="_blank" rel="noopener" href="http://www.brooklyn-usa.org/topography/"><strong>website</strong> {{fa-icon 'external-link' }}</a></li>
+        <li>Manhattan – <a target="_blank" rel="noopener" href="http://manhattanbp.nyc.gov/html/land_use/topographical-services.shtml"><strong>website</strong> {{fa-icon 'external-link' }}</a></li>
+        <li>Queens – <a target="_blank" rel="noopener" href="http://www.queensbp.org/land-use/"><strong>website</strong> {{fa-icon 'external-link' }}</a></li>
+        <li>Staten Island – <a target="_blank" rel="noopener" href="https://www.statenislandusa.com/staffdirectory.html"><strong>website</strong> {{fa-icon 'external-link' }}</a></li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+{{yield}}

--- a/app/templates/components/custom-controls.hbs
+++ b/app/templates/components/custom-controls.hbs
@@ -26,14 +26,7 @@
             <div class="share-controls-copy-success-message">{{fa-icon 'check'}} Copied</div>
           </div>
         {{/if}}
-        <p>For more information about the City Map, contact the Borough President's office.</p>
-        <ul class="no-margin">
-          <li>Bronx: <a href="mailto:foo@bar.org">foo@bar.org {{fa-icon 'envelope-o'}}</a></li>
-          <li>Brooklyn: <a href="mailto:foo@bar.org">foo@bar.org {{fa-icon 'envelope-o'}}</a></li>
-          <li>Manhattan: <a href="mailto:foo@bar.org">foo@bar.org {{fa-icon 'envelope-o'}}</a></li>
-          <li>Queens: <a href="mailto:foo@bar.org">foo@bar.org {{fa-icon 'envelope-o'}}</a></li>
-          <li>Staten Island: <a href="mailto:foo@bar.org">foo@bar.org {{fa-icon 'envelope-o'}}</a></li>
-        </ul>
+        {{boro-office-contact-callout class="text-tiny"}}
       </div>
     {{/if}}
   </div>

--- a/app/templates/feedback.hbs
+++ b/app/templates/feedback.hbs
@@ -9,20 +9,7 @@
 
   <p class="text-small">This street information has never been so easy to access, but NYC Street Map is only a starting point for research about the City’s streets. It lacks some information on the City Map and may have inaccuracies.  All information gathered from NYC Street Map must be confirmed based on the official City Map records.</p>
 
-  <div class="callout secondary text-small">
-    <div class="grid-x">
-      <p class="cell medium-6">To confirm what you see in NYC Street Map with official City Map records, please contact the relevant Borough President’s Topographic Office:</p>
-      <div class="cell medium-6">
-        <ul>
-          <li>Bronx – <a target="_blank" rel="noopener" href="http://bronxboropres.nyc.gov/topography/"><strong>website</strong> {{fa-icon 'external-link' }}</a></li>
-          <li>Brooklyn – <a target="_blank" rel="noopener" href="http://www.brooklyn-usa.org/topography/"><strong>website</strong> {{fa-icon 'external-link' }}</a></li>
-          <li>Manhattan – <a target="_blank" rel="noopener" href="http://manhattanbp.nyc.gov/html/land_use/topographical-services.shtml"><strong>website</strong> {{fa-icon 'external-link' }}</a></li>
-          <li>Queens – <a target="_blank" rel="noopener" href="http://www.queensbp.org/land-use/"><strong>website</strong> {{fa-icon 'external-link' }}</a></li>
-          <li>Staten Island – <a target="_blank" rel="noopener" href="https://www.statenislandusa.com/staffdirectory.html"><strong>website</strong> {{fa-icon 'external-link' }}</a></li>
-        </ul>
-      </div>
-    </div>
-  </div>
+  {{boro-office-contact-callout class="text-small"}}
 
   <h3 class="header-medium small-margin-bottom">NYC Street Map Application Feedback</h3>
 

--- a/tests/integration/components/boro-office-contact-callout-test.js
+++ b/tests/integration/components/boro-office-contact-callout-test.js
@@ -1,0 +1,26 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | boro-office-contact-callout', function(hooks) {
+  setupRenderingTest(hooks);
+
+  skip('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{boro-office-contact-callout}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#boro-office-contact-callout}}
+        template block text
+      {{/boro-office-contact-callout}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});


### PR DESCRIPTION
This PR adds a component for the boro office contact info, as it's in two places (feedback page and share modal). 