### PR TITLE
Extend model for "Data Sources" list on data page

### DIFF
--- a/app/models/layer-group.js
+++ b/app/models/layer-group.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+import LayerGroup from 'ember-labs-maps/models/layer-group';
+
+export default LayerGroup.extend({
+  meta: DS.attr(),
+});

--- a/app/templates/data.hbs
+++ b/app/templates/data.hbs
@@ -35,7 +35,7 @@
             {{/each}}
           {{/if}}
           {{#if layerGroup.meta.updated_at}}
-            <span style="display:block;" class="dark-gray text-small">Updated in ZoLa: {{layerGroup.meta.updated_at}}</span>
+            <span style="display:block;" class="dark-gray text-small">Updated: {{layerGroup.meta.updated_at}}</span>
           {{/if}}
         </p>
       </li>


### PR DESCRIPTION
This PR extends the `layer-group` model in the addon to get meta info for Data page. 