### PR TITLE
Data Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,49 @@ The App is deployed to our VPS using Dokku, you need only do a `git push` of the
 - To Deploy: `git push dokku master`
 - To deploy a branch other than master, alias it to master: `git push dokku {branchname}:master`
 
+## Uploading New Files to Digital Ocean Spaces
+
+1. Ask the client to send you the new files they want uploaded to the app. This can be over Slack, Box, Dropbox, etc. 
+2. Download the new files in a folder on your machine. 
+
+3. Before uploading these files to Spaces,  you need to install s3cmd on your machine. You can download the file here: https://s3tools.org/download 
+4. Once you have s3cmd downloaded, navigate (in your terminal) to the s3cmd folder you just downloaded
+5. Run the command 	$ sudo python setup.py install
+6. Then run 		$ s3cmd --configure
+
+	Fill in the new config options:
+
+Access Key: access key (this will be given to you by another team member)
+Secret Key: secret key (this will be given to you by another team member)
+Default Region [US]: [press enter]
+S3 Endpoint: nyc3.digitaloceanspaces.com
+DNS-style bucket+hostname: %(bucket)s.nyc3.digitaloceanspaces.com
+Encryption password: [press enter]
+Path to GPG program: [press enter]
+Use HTTPS protocol [Yes/No]: Yes
+HTTP Proxy server name: [press enter]
+Test access with supplied credentials? [Y/n] y
+
+//If you see this error about GPG program, type in "n" for Retry configuration 
+
+ERROR: Test failed: GPG program not found
+Retry configuration? [Y/n] n
+
+Save settings? [y/N] y
+Configuration saved to '/Users/YourFile/.s3cfg'
+
+7. After setting up the config, navigate to the directory with the files you downloaded from the client, and run this command in the terminal: 
+
+	$  s3cmd --acl-public put ./* s3://nycdcp-dcm-alteration-maps --recursive
+
+	// “--acl-public” allows anyone to view the file online
+	// “ ./* ” signifies a specific path to follow to locate the folder
+	// “s3://nycdcp-dcm-alteration-maps” is the folder on Spaces where you are adding the new files
+	// "--recursive" is necessary to upload a directory
+
+8. Make sure to have another team member add you to the Digital Ocean account. You will receive an email when you have been added. Create a new account from this email, and now you are able to view the files that have been uploaded to the Spaces folder. 
+
+
 ## Contact us
 
 You can find us on Twitter at [@nycplanninglabs](https://twitter.com/nycplanninglabs), or comment on issues and we'll follow up as soon as we can. If you'd like to send an email, use [labs_dl@planning.nyc.gov](mailto:labs_dl@planning.nyc.gov)

--- a/app/components/custom-controls.js
+++ b/app/components/custom-controls.js
@@ -14,13 +14,13 @@ export default class CustomControls extends Component {
   @argument boundsGeoJSON;
 
   datasets = [
-    { tableName: 'citymap_citymap_v0', displayName: 'City Street Features' },
-    { tableName: 'citymap_amendments_v0', displayName: 'City Map Amendments' },
-    { tableName: 'citymap_streetcenterlines_v0', displayName: 'Street Centerlines' },
+      { tableName: 'citymap_citymap_v1', displayName: 'City Street Features' },
+    { tableName: 'citymap_amendments_v3', displayName: 'City Map Amendments' },
+    { tableName: 'citymap_streetcenterlines_v1', displayName: 'Street Centerlines' },
     { tableName: 'citymap_streetnamechanges_points_v0', displayName: 'Street Name Changes - Points' },
     { tableName: 'citymap_streetnamechanges_streets_v0', displayName: 'Street Name Changes - Streets' },
     { tableName: 'citymap_streetnamechanges_areas_v0', displayName: 'Street Name Changes - Areas' },
-    { tableName: 'citymap_pierheadlines_v0', displayName: 'Pierhead and Bulkhead Lines' },
+    { tableName: 'citymap_pierheadlines_v1', displayName: 'Pierhead and Bulkhead Lines' },
     { tableName: 'citymap_arterials_v0', displayName: 'Arterials' },
   ]
 

--- a/app/components/custom-controls.js
+++ b/app/components/custom-controls.js
@@ -14,7 +14,7 @@ export default class CustomControls extends Component {
   @argument boundsGeoJSON;
 
   datasets = [
-      { tableName: 'citymap_citymap_v1', displayName: 'City Street Features' },
+    { tableName: 'citymap_citymap_v1', displayName: 'City Street Features' },
     { tableName: 'citymap_amendments_v3', displayName: 'City Map Amendments' },
     { tableName: 'citymap_streetcenterlines_v1', displayName: 'Street Centerlines' },
     { tableName: 'citymap_streetnamechanges_points_v0', displayName: 'Street Name Changes - Points' },

--- a/app/components/labs-map-legend-railroad.js
+++ b/app/components/labs-map-legend-railroad.js
@@ -1,0 +1,25 @@
+import Component from '@ember/component';
+import { argument } from '@ember-decorators/argument';
+import { tagName, classNames, attribute } from '@ember-decorators/component';
+import layout from '../templates/components/labs-map-legend-railroad';
+
+@tagName('svg')
+@classNames('legend-icon', 'line-array')
+export default class LabsMapLegendLineComponent extends Component {
+  layout = layout
+
+  @attribute height = 10;
+  @attribute width = 17;
+  @attribute viewBox = '0 0 17 10';
+  @attribute preserveAspectRatio = 'xMinYMid';
+
+  @argument style = {};
+
+  didInsertElement() {
+    const groupElement = this.element.querySelector('.cross');
+    const style = this.get('style');
+    Object.entries(style).forEach(([attr, value]) => {
+      groupElement.setAttribute(attr, value);
+    });
+  }
+}

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -264,7 +264,7 @@ export default class ApplicationController extends ParachuteController {
     const { lng, lat } = e.lngLat;
     const SQL = `
     SELECT the_geom, 'alteration' AS type, altmappdf, status, effective, NULL AS bbl, NULL AS address
-      FROM citymap_amendments_v2
+      FROM citymap_amendments_v3
       WHERE (effective IS NOT NULL
               OR status = '13')
         AND ST_Intersects(

--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -7,11 +7,14 @@
 
   <p class="lead">NYC Street Map is an ongoing effort to digitize official street records, bring them together with other street information, and make them easily accessible to the public. With this app, you can find the official mapped width, name, and status of specific streets and how they may relate to specific properties. You can also see how the street grid has changed over time in your area.</p>
 
-  <p>By searching for addresses, street names, alterations (e.g. cp21423), and ULURP numbers (e.g. 841080mmk) you can locate their positions on the map. This application only includes alteration and ULURP numbers relevant to official street records. If you are interested in searching for ULURP numbers associated with zoning change projects instead, you can find project profiles by ULURP number in our <a href="https://zap.planning.nyc.gov/projects" target="_blank">ZAP Search application</a></p>
-
   <p>NYC Street Map combines 8000+ components of the official City Map with other street information into a seamless Citywide map. However, NYC Street Map does not contain all the information on the City Map and may have inaccuracies. The information shown on NYC Street Map must be confirmed based on the official City Map records.</p>
 
   {{#link-to 'city-map' class="button secondary expanded"}}<strong>Learn more about the official City Map&hellip;</strong>{{/link-to}}
+
+  <hr>
+
+  <h4>How to find alterations</h4>
+  <p>Search for an address, street name, alteration number (e.g. cp21423), or ULURP number (e.g. 841080mmk) and easily locate them on the map. Search results only include ULURP numbers or alteration numbers relevant to official street records. You can find ULURP numbers associated with zoning change projects in <a href="https://zap.planning.nyc.gov/projects" target="_blank" rel="noopener noreferrer">ZAP Search application</a>.</p>
 
   <hr>
 

--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -7,6 +7,8 @@
 
   <p class="lead">NYC Street Map is an ongoing effort to digitize official street records, bring them together with other street information, and make them easily accessible to the public. With this app, you can find the official mapped width, name, and status of specific streets and how they may relate to specific properties. You can also see how the street grid has changed over time in your area.</p>
 
+  <p>By searching for addresses, street names, alterations (e.g. cp21423), and ULURP numbers (e.g. 841080mmk) you can locate their positions on the map. This application only includes alteration and ULURP numbers relevant to official street records. If you are interested in searching for ULURP numbers associated with zoning change projects instead, you can find project profiles by ULURP number in our <a href="https://zap.planning.nyc.gov/projects" target="_blank">ZAP Search application</a></p>
+
   <p>NYC Street Map combines 8000+ components of the official City Map with other street information into a seamless Citywide map. However, NYC Street Map does not contain all the information on the City Map and may have inaccuracies. The information shown on NYC Street Map must be confirmed based on the official City Map records.</p>
 
   {{#link-to 'city-map' class="button secondary expanded"}}<strong>Learn more about the official City Map&hellip;</strong>{{/link-to}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -12,14 +12,14 @@
         typeTitleLookup=(hash
           lot='Addresses'
           city-street='Streets'
-          city-map-alteration='Alterations'
+          city-map-alteration='Alterations and ULURP Numbers'
         ) as |search|}}
       {{#if (eq search.result.type 'lot')}}
         <span class="icon tax-lot"></span> <span class="subdued">{{search.result.label}}, Block {{search.result.demuxedBbl.block}}, Lot {{search.result.demuxedBbl.lot}}</span>
       {{else if (eq search.result.type 'city-street')}}
         {{search.result.label}} ({{search.result.boro_name}})
       {{else if (eq search.result.type 'city-map-alteration')}}
-        {{search.result.label}} ({{moment-format search.result.effective 'DD MMMM YYYY' 'X'}})
+        {{search.result.label}} ({{moment-format search.result.effective 'DD MMMM YYYY'}})
       {{/if}}
     {{/labs-search}}
     {{bbl-lookup flyTo=(action 'flyTo')}}

--- a/app/templates/components/labs-map-legend-railroad.hbs
+++ b/app/templates/components/labs-map-legend-railroad.hbs
@@ -1,0 +1,4 @@
+<path class="cross" d="M0 5 l215 0" />
+<path d="M0 5 l215 0" fill="none" stroke="grey" stroke-width="0.5"></path>
+
+{{yield}}

--- a/json/layer-groups/citymap.json
+++ b/json/layer-groups/citymap.json
@@ -1,6 +1,6 @@
 {
   "id":"citymap",
-  "title":"Street Lines",
+  "title":"Street Map Features",
   "legendIcon":"",
   "legendColor":"",
   "visible":true,
@@ -270,6 +270,205 @@
           "line-cap":"round"
         }
       }
+    },
+      {
+        "tooltipable":true,
+        "tooltipTemplate":"{{boro_nm}}",
+        "style":{
+          "id":"borough-boundaries",
+          "type":"line",
+          "source":"digital-citymap",
+          "source-layer":"citymap",
+          "paint":{
+            "line-color": "#4e5050",
+            "line-width":{
+              "stops":[
+                [
+                  10,
+                  0.8
+                ],
+                [
+                  13,
+                  2
+                ],
+                [
+                  15,
+                  4
+                ]
+              ]
+            }
+          },
+          "filter":[
+            "all",
+            [
+              "==",
+              "type",
+              "City_boundary"
+            ]
+          ]
+        }
+      },
+      {
+      "style":{
+        "id":"citymap-underpass-tunnel-line",
+        "type":"line",
+        "source":"digital-citymap",
+        "source-layer":"citymap",
+        "filter":[
+          "all",
+          [
+            "==",
+            "type",
+            "Underpass or Tunnel"
+          ]
+        ],
+        "paint":{
+          "line-color": {
+            "stops": [
+              [
+                10,
+                "rgba(150, 150, 150, 0.3)"
+              ],
+              [
+                13,
+                "rgba(150, 150, 150, 1)"
+              ]
+            ]
+          },
+          "line-width":{
+            "stops":[
+              [
+                10,
+                0.1
+              ],
+              [
+                13,
+                0.25
+              ],
+              [
+                15,
+                1
+              ]
+            ]
+          },
+          "line-dasharray":{
+            "stops":[
+              [
+                10,
+                [
+                  6,
+                  4
+                ]
+              ],
+              [
+                15,
+                [
+                  10,
+                  6
+                ]
+              ]
+            ]
+          }
+        }
+      }
+    },
+    {
+    "tooltipable":true,
+    "tooltipTemplate":"{{street}}",
+    "style":{
+      "id":"railway-lines",
+      "type":"line",
+      "source":"digital-citymap",
+      "source-layer":"rail-lines",
+      "paint":{
+        "line-color": {
+          "stops": [
+            [
+              10,
+              "#9ca0a1"
+            ],
+            [
+              13,
+              "#9ca0a1"
+            ]
+          ]
+        },
+        "line-width":{
+          "stops":[
+            [
+              10,
+              0.5
+            ],
+            [
+              13,
+              1
+            ],
+            [
+              15,
+              2
+            ]
+          ]
+        }
+      }
+    }
+  },
+  {
+  "tooltipable":true,
+  "tooltipTemplate":"{{street}}",
+  "style":{
+    "id":"railway-cross-lines",
+    "type":"line",
+    "source":"digital-citymap",
+    "source-layer":"rail-lines",
+    "paint":{
+      "line-color": {
+        "stops": [
+          [
+            10,
+            "grey"
+          ],
+          [
+            13,
+            "grey"
+          ]
+        ]
+      },
+      "line-width":{
+        "stops":[
+          [
+            10,
+            2
+          ],
+          [
+            13,
+            4
+          ],
+          [
+            15,
+            6
+          ]
+        ]
+      },
+      "line-dasharray":{
+        "stops":[
+          [
+            10,
+            [
+              0.2,
+              4
+            ]
+          ],
+          [
+            15,
+            [
+              0.2,
+              4
+            ]
+          ]
+        ]
+      }
+      }
+      }
     }
   ],
   "legendConfig": {
@@ -303,6 +502,26 @@
           "stroke":"rgba(50, 50, 50, 0.4)",
           "stroke-width":"0.5",
           "stroke-dasharray":"1"
+        }
+      },
+      {
+        "type":"line",
+        "label":"Rail",
+        "tooltip":"Railways",
+        "style":{
+          "fill":"none",
+          "stroke":"grey",
+          "stroke-width":"2",
+          "stroke-dasharray":"0.6, 2"
+        }
+      },
+      {
+        "type":"line",
+        "label":"Borough Boundaries",
+        "tooltip":"The boundaries between the five boroughs",
+        "style":{
+          "fill":"none",
+          "stroke": "rgba(105, 105, 105, 1)"
         }
       }
     ]

--- a/json/layer-groups/citymap.json
+++ b/json/layer-groups/citymap.json
@@ -285,7 +285,7 @@
               "stops":[
                 [
                   10,
-                  0.8
+                  1
                 ],
                 [
                   13,
@@ -505,7 +505,7 @@
         }
       },
       {
-        "type":"line",
+        "type":"railroad",
         "label":"Rail",
         "tooltip":"Railways",
         "style":{

--- a/json/layer-groups/citymap.json
+++ b/json/layer-groups/citymap.json
@@ -425,11 +425,11 @@
         "stops": [
           [
             10,
-            "grey"
+            "#9ca0a1"
           ],
           [
             13,
-            "grey"
+            "#9ca0a1"
           ]
         ]
       },
@@ -510,7 +510,7 @@
         "tooltip":"Railways",
         "style":{
           "fill":"none",
-          "stroke":"grey",
+          "stroke":"#9ca0a1",
           "stroke-width":"2",
           "stroke-dasharray":"0.6, 2"
         }
@@ -518,10 +518,10 @@
       {
         "type":"line",
         "label":"Borough Boundaries",
-        "tooltip":"The boundaries between the five boroughs",
+        "tooltip":"",
         "style":{
           "fill":"none",
-          "stroke": "rgba(105, 105, 105, 1)"
+          "stroke": "#4e5050"
         }
       }
     ]

--- a/json/layer-groups/citymap.json
+++ b/json/layer-groups/citymap.json
@@ -507,7 +507,7 @@
       {
         "type":"railroad",
         "label":"Rail",
-        "tooltip":"Railways",
+        "tooltip":"Railroad right-of-way",
         "style":{
           "fill":"none",
           "stroke":"#9ca0a1",

--- a/json/layer-groups/citymap.json
+++ b/json/layer-groups/citymap.json
@@ -280,20 +280,20 @@
           "source":"digital-citymap",
           "source-layer":"citymap",
           "paint":{
-            "line-color": "#4e5050",
+            "line-color": "rgba(50,100,100,0.4)",
             "line-width":{
               "stops":[
                 [
                   10,
-                  1
+                  3
                 ],
                 [
                   13,
-                  2
+                  4
                 ],
                 [
                   15,
-                  4
+                  5
                 ]
               ]
             }
@@ -521,7 +521,8 @@
         "tooltip":"",
         "style":{
           "fill":"none",
-          "stroke": "#4e5050"
+          "stroke-width":"3",
+          "stroke": "rgba(50,100,100,0.4)"
         }
       }
     ]

--- a/json/layer-groups/pierhead-bulkhead-lines.json
+++ b/json/layer-groups/pierhead-bulkhead-lines.json
@@ -12,14 +12,14 @@
   "layers": [
     {
       "tooltipable": true,
-      "tooltipTemplate": "Pierhead Line",
+      "tooltipTemplate": "US Pierhead Line",
       "style": {
-        "id": "citymap-pierhead-line",
+        "id": "citymap-pierhead-line-US",
         "type": "line",
         "source": "digital-citymap",
         "source-layer": "pierhead-lines",
         "paint": {
-          "line-color": "rgba(50, 120, 200, 1)",
+          "line-color": "#fc9272",
           "line-width": {
             "stops": [
               [
@@ -32,6 +32,7 @@
               ]
             ]
           },
+
           "line-opacity": 1,
           "line-dasharray": [
             5,
@@ -46,19 +47,85 @@
         },
         "layout": {
           "line-cap": "round"
-        }
+        },
+        "filter":[
+          "any",
+          [
+            "==",
+            "jurisdicti",
+            "U.S."
+          ],
+          [
+            "==",
+            "jurisdicti",
+            "US"
+          ],
+          [
+            "==",
+            "jurisdicti",
+            "unknown"
+          ]
+        ]
       }
     },
     {
       "tooltipable": true,
-      "tooltipTemplate": "Bulkhead Line",
+      "tooltipTemplate": "NYC Pierhead Line",
       "style": {
-        "id": "citymap-bulkhead-line",
+        "id": "citymap-pierhead-line-NYC",
+        "type": "line",
+        "source": "digital-citymap",
+        "source-layer": "pierhead-lines",
+        "paint": {
+          "line-color": "#de2d26",
+          "line-width": {
+            "stops": [
+              [
+                10,
+                0.5
+              ],
+              [
+                14,
+                3
+              ]
+            ]
+          },
+
+          "line-opacity": 1,
+          "line-dasharray": [
+            5,
+            2,
+            0,
+            1.5,
+            0,
+            1.5,
+            0,
+            2
+          ]
+        },
+        "layout": {
+          "line-cap": "round"
+        },
+        "filter":[
+          "any",
+          [
+            "==",
+            "jurisdicti",
+            "City of New York"
+          ]
+        ]
+      }
+    },
+    {
+      "tooltipable": true,
+      "tooltipTemplate": "US Bulkhead Line",
+      "style": {
+        "id": "citymap-bulkhead-line-US",
         "type": "line",
         "source": "digital-citymap",
         "source-layer": "bulkhead-lines",
         "paint": {
-          "line-color": "#3278C8",
+          "line-color": "#2ca2b8",
           "line-width": {
             "stops": [
               [
@@ -83,32 +150,152 @@
         },
         "layout": {
           "line-cap": "round"
+        },
+        "filter":[
+          "any",
+          [
+            "==",
+            "jurisdicti",
+            "U.S."
+          ],
+          [
+            "==",
+            "jurisdicti",
+            "unknown"
+          ]
+        ]
+        }
+      },
+    {
+      "tooltipable": true,
+      "tooltipTemplate": "NYC Bulkhead Line",
+      "style": {
+        "id": "citymap-bulkhead-line-NYC",
+        "type": "line",
+        "source": "digital-citymap",
+        "source-layer": "bulkhead-lines",
+        "paint": {
+          "line-color": "#1d547a",
+          "line-width": {
+            "stops": [
+              [
+                10,
+                0.5
+              ],
+              [
+                14,
+                3
+              ]
+            ]
+          },
+          "line-opacity": 1,
+          "line-dasharray": [
+            5,
+            2.5,
+            0,
+            2,
+            0,
+            2.5
+          ]
+        },
+        "layout": {
+          "line-cap": "round"
+        },
+          "filter":[
+            "all",
+            [
+              "==",
+              "jurisdicti",
+              "City of New York"
+            ]
+          ]
+        }
+      },
+      {
+        "tooltipable":true,
+        "tooltipTemplate":"Water Edge",
+        "style":{
+          "id":"water-edge",
+          "type":"line",
+          "source":"digital-citymap",
+          "source-layer":"citymap",
+          "paint":{
+            "line-color": "#757879",
+            "line-width":{
+              "stops":[
+                [
+                  10,
+                  0.5
+                ],
+                [
+                  14,
+                  3
+                ]
+              ]
+            }
+          },
+          "filter":[
+            "all",
+            [
+              "==",
+              "type",
+              "Water line"
+            ]
+          ]
         }
       }
-    }
   ],
   "legendConfig": {
     "label": "Water Lines",
     "items": [
       {
          "type": "line",
-         "label": "Pierhead Line",
+         "label": "US Pierhead Line",
          "style": {
            "fill": "none",
-           "stroke": "#3278C8",
+           "stroke": "#fc9272",
            "stroke-linecap": "round",
            "stroke-dasharray": "5,2.5,0,2,0,2.5"
          }
       },
       {
          "type": "line",
-         "label": "Bulkhead Line",
+         "label": "NYC Pierhead Line",
          "style": {
            "fill": "none",
-           "stroke": "#3278C8",
+           "stroke": "#de2d26",
+           "stroke-linecap": "round",
+           "stroke-dasharray": "5,2.5,0,2,0,2.5"
+         }
+      },
+      {
+         "type": "line",
+         "label": "US Bulkhead Line",
+         "style": {
+           "fill": "none",
+           "stroke": "#2ca2b8",
            "stroke-linecap": "round",
            "stroke-dasharray": "5,2,0,1.5,0,1.5,0,2"
          }
+      },
+      {
+         "type": "line",
+         "label": "NYC Bulkhead Line",
+         "style": {
+           "fill": "none",
+           "stroke": "#1d547a",
+           "stroke-linecap": "round",
+           "stroke-dasharray": "5,2,0,1.5,0,1.5,0,2"
+         }
+      },
+      {
+        "type":"line",
+        "label":"Water Edge",
+        "tooltip":"When there are no pierhead or bulkhead lines, boundaries are marked by the water's edge",
+        "style":{
+          "fill":"none",
+          "stroke": "#757879"
+        }
       }
     ]
   }

--- a/json/layer-groups/pierhead-bulkhead-lines.json
+++ b/json/layer-groups/pierhead-bulkhead-lines.json
@@ -11,6 +11,39 @@
   },
   "layers": [
     {
+      "tooltipable":true,
+      "tooltipTemplate":"Water Edge",
+      "style":{
+        "id":"water-edge",
+        "type":"line",
+        "source":"digital-citymap",
+        "source-layer":"citymap",
+        "paint":{
+          "line-color": "#b0b5b5",
+          "line-width":{
+            "stops":[
+              [
+                10,
+                0.5
+              ],
+              [
+                14,
+                2
+              ]
+            ]
+          }
+        },
+        "filter":[
+          "all",
+          [
+            "==",
+            "type",
+            "Water line"
+          ]
+        ]
+      }
+    },
+    {
       "tooltipable": true,
       "tooltipTemplate": "US Pierhead Line",
       "style": {
@@ -207,39 +240,6 @@
               "==",
               "jurisdicti",
               "City of New York"
-            ]
-          ]
-        }
-      },
-      {
-        "tooltipable":true,
-        "tooltipTemplate":"Water Edge",
-        "style":{
-          "id":"water-edge",
-          "type":"line",
-          "source":"digital-citymap",
-          "source-layer":"citymap",
-          "paint":{
-            "line-color": "#757879",
-            "line-width":{
-              "stops":[
-                [
-                  10,
-                  0.5
-                ],
-                [
-                  14,
-                  3
-                ]
-              ]
-            }
-          },
-          "filter":[
-            "all",
-            [
-              "==",
-              "type",
-              "Water line"
             ]
           ]
         }

--- a/public/sources.json
+++ b/public/sources.json
@@ -5,7 +5,7 @@
     "source-layers": [
       {
         "id": "bulkhead-lines",
-        "sql": "SELECT the_geom_webmercator FROM citymap_bulkheadlines_v0"
+        "sql": "SELECT the_geom_webmercator, jurisdicti FROM citymap_bulkheadlines_v1"
       },
       {
         "id": "arterials",
@@ -13,19 +13,19 @@
       },
       {
         "id": "pierhead-lines",
-        "sql": "SELECT the_geom_webmercator FROM citymap_pierheadlines_v0"
+        "sql": "SELECT the_geom_webmercator, jurisdicti FROM citymap_pierheadlines_v1"
       },
       {
         "id": "amendments",
-        "sql": "SELECT the_geom_webmercator, ST_Area(the_geom) as area, cartodb_id as id, altmappdf, extract(epoch from effective) as effective, status FROM citymap_amendments_v2 WHERE effective IS NOT NULL OR status = '13' ORDER BY area DESC"
+        "sql": "SELECT the_geom_webmercator, ST_Area(the_geom) as area, cartodb_id as id, altmappdf, SUBSTRING(altmappdf, 1, 6) AS ulurp, extract(epoch from effective) as effective, status FROM citymap_amendments_v3 WHERE effective IS NOT NULL OR status = '13' ORDER BY area DESC"
       },
       {
         "id": "street-centerlines",
-        "sql": "SELECT the_geom_webmercator, official_s AS streetname, COALESCE('   (' || streetwidt || ' ft)') AS streetwidth, roadway_ty, feature_st FROM citymap_streetcenterlines_v0"
+        "sql": "SELECT the_geom_webmercator, official_s AS streetname, COALESCE('   (' || streetwidt || ' ft)') AS streetwidth, roadway_ty, feature_st FROM citymap_streetcenterlines_v1"
       },
       {
         "id": "citymap",
-        "sql": "SELECT the_geom_webmercator, type FROM citymap_citymap_v0"
+        "sql": "SELECT the_geom_webmercator, type, boro_nm FROM citymap_citymap_v1"
       },
       {
         "id": "name-changes-points",
@@ -38,6 +38,10 @@
       {
         "id": "name-changes-areas",
         "sql": "SELECT the_geom_webmercator, intronumbe, intro_year, ll_effecti, CASE WHEN honoraryna = 'none' THEN officialna ELSE honoraryna END FROM citymap_streetnamechanges_areas_v0"
+      },
+      {
+        "id": "rail-lines",
+        "sql": "SELECT the_geom_webmercator, street FROM citymap_rails_v0"
       }
     ]
   },

--- a/public/sources.json
+++ b/public/sources.json
@@ -17,7 +17,7 @@
       },
       {
         "id": "amendments",
-        "sql": "SELECT the_geom_webmercator, ST_Area(the_geom) as area, cartodb_id as id, altmappdf, SUBSTRING(altmappdf, 1, 6) AS ulurp, extract(epoch from effective) as effective, status FROM citymap_amendments_v3 WHERE effective IS NOT NULL OR status = '13' ORDER BY area DESC"
+        "sql": "SELECT the_geom_webmercator, ST_Area(the_geom) as area, cartodb_id as id, altmappdf, extract(epoch from effective) as effective, status FROM citymap_amendments_v3 WHERE effective IS NOT NULL OR status = '13' ORDER BY area DESC"
       },
       {
         "id": "street-centerlines",

--- a/tests/acceptance/user-toggles-layers-test.js
+++ b/tests/acceptance/user-toggles-layers-test.js
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { visit, click, triggerEvent, pauseTest, find } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 
@@ -7,7 +7,7 @@ module('Acceptance | user toggles layers', function(hooks) {
 
   test('User toggles layers', async function(assert) {
     await visit('/');
-    await click('.layer-street-lines .layer-menu-item-title');
+    await click('.layer-street-map-features .layer-menu-item-title');
     await click('.layer-street-names .layer-menu-item-title');
     await click('.layer-local-law-names .layer-menu-item-title');
     // await click('.layer-city-map-alterations .layer-menu-item-title');

--- a/tests/integration/components/labs-map-legend-railroad-test.js
+++ b/tests/integration/components/labs-map-legend-railroad-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | labs-map-legend-railroad', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{labs-map-legend-railroad}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#labs-map-legend-railroad}}
+        template block text
+      {{/labs-map-legend-railroad}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/tests/unit/utils/normalize-carto-vectors-test.js
+++ b/tests/unit/utils/normalize-carto-vectors-test.js
@@ -8,7 +8,7 @@ const plutoSource = {
   'source-layers': [
     {
       id: 'pluto',
-      sql: 'SELECT the_geom_webmercator, sourceimag, cartodb_id FROM citymap_bulkheadlines_v0',
+      sql: 'SELECT the_geom_webmercator, sourceimag, cartodb_id FROM citymap_bulkheadlines_v1',
     },
   ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -329,6 +329,10 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
+abortcontroller-polyfill@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.1.9.tgz#9fefe359fda2e9e0932dc85e6106453ac393b2da"
+
 accepts@~1.3.4, accepts@~1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
@@ -2238,7 +2242,7 @@ cartobox-promises-utility@nycplanning/cartobox-promises-utility:
   resolved "https://codeload.github.com/nycplanning/cartobox-promises-utility/tar.gz/0cc2da9b0e1c1589a810e0aa5f4d070b82d4310f"
   dependencies:
     ember-cli-babel "^6.6.0"
-    ember-fetch "4.0.1"
+    ember-fetch "5.0.0"
 
 caseless@~0.11.0:
   version "0.11.0"
@@ -3629,6 +3633,19 @@ ember-fetch@3.4.5:
     node-fetch "^2.0.0-alpha.9"
     whatwg-fetch "^2.0.3"
 
+ember-fetch@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/ember-fetch/-/ember-fetch-4.0.1.tgz#0d43517c5e26de7ebd0777c983d675e79ecb40ad"
+  dependencies:
+    abortcontroller-polyfill "^1.1.9"
+    broccoli-concat "^3.2.2"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-stew "^1.4.2"
+    broccoli-templater "^1.0.0"
+    ember-cli-babel "^6.8.2"
+    node-fetch "^2.0.0-alpha.9"
+    yetch "^0.0.1"
+
 ember-font-awesome@^4.0.0-rc.2:
   version "4.0.0-rc.2"
   resolved "https://registry.yarnpkg.com/ember-font-awesome/-/ember-font-awesome-4.0.0-rc.2.tgz#27735f57eb56509b51f2b5000da85e7fd84791df"
@@ -3670,14 +3687,18 @@ ember-labs-maps@nycplanning/ember-labs-maps:
   version "0.0.0"
   resolved "https://codeload.github.com/nycplanning/ember-labs-maps/tar.gz/14138fd89f6d64ccee248884373dbccdab5b7f67"
   dependencies:
-    "@ember-decorators/argument" "0.8.13"
+    "@ember-decorators/argument" "0.8.15"
     "@ember-decorators/babel-transforms" "^2.0.0"
+    cartobox-promises-utility nycplanning/cartobox-promises-utility#v1.0.1
     ember-cli-babel "^6.6.0"
     ember-cli-htmlbars "^2.0.1"
     ember-cli-htmlbars-inline-precompile "^1.0.0"
-    ember-decorators "2.0.0"
+    ember-decorators "2.1.0"
+    ember-font-awesome "^4.0.0-rc.2"
     ember-mapbox-gl "0.10.0"
+    ember-tooltips "^3.0.0-beta.2"
     ember-truth-helpers "2.0.0"
+    pretender "2.0.0"
 
 ember-load-initializers@^1.0.0:
   version "1.0.0"
@@ -9455,3 +9476,7 @@ yargs@~3.10.0:
 yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
+
+yetch@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/yetch/-/yetch-0.0.1.tgz#76f1729b2c2c667e23c3c2da90472a4897eca004"


### PR DESCRIPTION
1. Updated file versions and added new datasets (rails, boroughs, NYC vs. US bulk/pierhead lines, water edge)
2. Updated Search (user can search by alteration or ulurp number, appears in same search results section)
3. Added text to “about” section detailing what the user can search
4. Fixed a bug in application.hbs, date in search results was incorrect (moment format), it was showing same date for each project despite different dates in data. Now it is currently showing correct date
5. Updated styling (pierhead/bulkhead lines, water’s edge, borough boundaries, rails—which include an update of the legend with svg) 
6. Changed “Street Lines” title to “Street Map Features”
7. Updated tests
